### PR TITLE
remove meta-virtualization from bblayers.sample

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -15,7 +15,6 @@ BBLAYERS ?= " \
     ##OEROOT##/meta-openembedded/meta-python \
     ##OEROOT##/meta-raspberrypi \
     ##OEROOT##/meta-security \
-    ##OEROOT##/meta-virtualization \
     ##OEROOT##/meta-gateway-ww \
     ##OEROOT##/meta-nodejs \
 "


### PR DESCRIPTION
this layer isn't used by WW builds, so we can remove it to
stop bitbake from complaining about it.