### PR TITLE
add bluetooth userspace utilities bluez5

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -19,6 +19,8 @@ MACHINE_FEATURES_remove = "apm"
 WKS_FILE = "console-image.wic"
 IMAGE_FSTYPES = "wic"
 
+DISTRO_FEATURES_append += " bluez5 bluetooth"
+
 # Choose the board you are building for
 #MACHINE="raspberrypi"
 #MACHINE="raspberrypi0"

--- a/images/console-image.bb
+++ b/images/console-image.bb
@@ -26,6 +26,10 @@ WIFI_SUPPORT = " \
     wpa-supplicant \
 "
 
+BLUETOOTH_SUPPORT = " \
+    bluez5 \
+"
+
 DEV_SDK_INSTALL = " \
     binutils \
     binutils-symlinks \
@@ -127,6 +131,7 @@ IMAGE_INSTALL += " \
     ${EXTRA_TOOLS_INSTALL} \
     ${RPI_STUFF} \
     ${WIFI_SUPPORT} \
+    ${BLUETOOTH_SUPPORT} \
     ${WIGWAG_STUFF} \
 "
 


### PR DESCRIPTION
in order to provide gateway services to bluetooth devices, we
need the bluetooth userspace utilities.