### PR TITLE
disable the console so that bluetooth works

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -45,8 +45,12 @@ MACHINE = "raspberrypi3"
 
 DISABLE_OVERSCAN = "1"
 ENABLE_UART = "1"
-ENABLE_RPI3_SERIAL_CONSOLE = "1"
-SERIAL_CONSOLES = "115200;ttyAMA0"
+
+# If you need serial console access, for example to debug uboot or
+# initramfs, uncomment the next two lines.  Be aware that doing this
+# disables the bluetooth radio, so do not leave this on by default.
+#ENABLE_RPI3_SERIAL_CONSOLE = "1"
+#SERIAL_CONSOLES = "115200;ttyAMA0"
 # SERIAL_CONSOLES_forcevariable = ""
 
 #DL_DIR = "${HOME}/oe-sources"


### PR DESCRIPTION
console access can be enabled for debugging of uboot and initramfs,
but at the cost of disabling the bluetooth radio.

in order to get bluetooth working by default, serial console
access must be disabled by default.