### PR TITLE
add wic.gz as an image type

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -24,7 +24,7 @@ VIRTUAL-RUNTIME_init_manager = "sysvinit"
 MACHINE_FEATURES_remove = "apm"
 
 WKS_FILE = "console-image.wic"
-IMAGE_FSTYPES = "${INITRAMFS_FSTYPES} wic"
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES} wic wic.gz"
 
 DISTRO_FEATURES_append += " bluez5 bluetooth"
 


### PR DESCRIPTION
this reduces the image size from 6.8GB for a .wic to 299MB
for a wic.gz, making it considerably easier to download.