### PR TITLE
Add missing mkfs tools to initramfs

### DIFF
--- a/recipes-core/images/ww-console-image-initramfs.bb
+++ b/recipes-core/images/ww-console-image-initramfs.bb
@@ -13,7 +13,8 @@ verify signatures and activating dm-verity."
 
 DEPENDS += "u-boot-mkimage-native"
 
-PACKAGE_INSTALL = "ww-console-image-initramfs-init util-linux-findfs busybox-initramfs e2fsprogs-e2fsck"
+PACKAGE_INSTALL = "ww-console-image-initramfs-init util-linux-findfs busybox-initramfs e2fsprogs-e2fsck e2fsprogs-mke2fs"
+FILES_e2fsprogs-mke2fs = "${base_sbindir}/mke2fs ${base_sbindir}/mkfs.ext* ${sysconfdir}/mke2fs.conf"
 
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""


### PR DESCRIPTION
The mkfs.ext4 tool is required by the upgrade script.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>