### PR TITLE
move the edge-core config folder to /userdata/mbed

### DIFF
--- a/recipes-wigwag/mbed-edge-core/files/rpi3/target.cmake
+++ b/recipes-wigwag/mbed-edge-core/files/rpi3/target.cmake
@@ -5,9 +5,9 @@ SET (PAL_TARGET_DEVICE "Yocto_Generic")
 
 SET (PAL_USER_DEFINED_CONFIGURATION "\"${TARGET_CONFIG_ROOT}/sotp_fs_rpi3_yocto.h\"")
 SET (BIND_TO_ALL_INTERFACES 0)
-SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/mnt/config\"")
-SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/mnt/config\"")
-SET (PAL_UPDATE_FIRMWARE_DIR "\"/mnt/cache/firmware\"")
+SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/userdata/mbed/mcc_config\"")
+SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/userdata/mbed/mcc_config\"")
+SET (PAL_UPDATE_FIRMWARE_DIR "\"/userdata/mbed/firmware\"")
 SET (ARM_UC_SOCKET_TIMEOUT_MS 300000)
 
 if (${FIRMWARE_UPDATE})


### PR DESCRIPTION
For the factory provisioning workflow, credentials are injected
by the fcc tool into /userdata/mbed/mcc_config.

We use /userdata for the gateway-ww builds because it is a
partition with persistence.