### PR TITLE
reorganize the CORE_OS package variable

### DIFF
--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -14,8 +14,6 @@ CORE_OS = " \
     openssh openssh-keygen openssh-sftp-server \
     packagegroup-core-boot \
     packagegroup-core-full-cmdline \    
-    packagegroup-core-buildessential \
-    term-prompt \
     tzdata \
 "
 
@@ -30,30 +28,17 @@ BLUETOOTH_SUPPORT = " \
 "
 
 DEV_SDK_INSTALL = " \
-    binutils \
-    binutils-symlinks \
     coreutils \
-    cpp \
-    cpp-symlinks \
     diffutils \
     elfutils elfutils-binutils \
     file \
-    g++ \
-    g++-symlinks \
-    gcc \
-    gcc-symlinks \
     gdb \
     gdbserver \
-    gettext \
     git \
     ldd \
-    libstdc++ \
-    libstdc++-dev \
-    libtool \
     ltrace \
-    make \
     nodejs \
-    pkgconfig \
+    packagegroup-core-buildessential \
     python3-modules \
     strace \
     openssl-dev \
@@ -110,6 +95,7 @@ WIGWAG_STUFF = " \
     pps-tools \
     pwgen \
     su-exec \
+    term-prompt \
     tsb \
     twlib \
     devicedb \


### PR DESCRIPTION
* moved packagegroup-core-buildessential to the DEV_SDK_INSTALL
  variable since the package contain build tools
* removed redundancies in DEV_SDK_INSTALL that were already
  provided by packagegroup-core-buildessential
* moved term-prompt, which is a CLI prompt tweak, into the
  WIGWAG_STUFF variable since the packages comes from the
  meta-gateway-ww meta.