### PR TITLE
fix path to /userdata/mbed/mcc_config

### DIFF
--- a/recipes-wigwag/mbed-edge-core/files/edge-core.init
+++ b/recipes-wigwag/mbed-edge-core/files/edge-core.init
@@ -13,8 +13,8 @@
 start_edge() {
     if [ ! -d "/userdata/mbed/mcc_config" ]; then
         # this directory is used to hold the developer certificate, if the user wants to use one
-        echo "Creating /userdata/mbed"
-        mkdir -p /userdata/mbed/mcc-config
+        echo "Creating /userdata/mbed/mcc_config"
+        mkdir -p /userdata/mbed/mcc_config
         chown developer -R /userdata/mbed
     fi
     cd /userdata/mbed


### PR DESCRIPTION
the edge-core startup script checks for the existence of the
secure storage folder before starting, but the directory that
the script created had a typo.