### PR TITLE
Ensure watchdog pid file can be created

### DIFF
--- a/recipes-core/ww-console-image-initramfs-init/files/initramfs-init-script.sh
+++ b/recipes-core/ww-console-image-initramfs-init/files/initramfs-init-script.sh
@@ -618,6 +618,7 @@ watchdog(){
 		say_init "enabling the watchdog with -w $wtime -d"
 		#Watchdog is hw dependent and must be build specially for each platform
 		#ignore errors until orperational
+		mkdirectory $WDPID_PATH
 		/deviceOSWD -w $wtime -d -s $WDKEEPALIVE -p $WDPID_PATH 2>/dev/null
 	else
 		say_error "watchdog not started"


### PR DESCRIPTION
deviceoswd ios run in daemon mode in the init script of initramfs.
Daemon mode will create a pid file for the process.  This change
ensures that the path for the pidfile exists before creation.

Signed-off-by Kyle Stein <kyle.stein@arm.com>