### PR TITLE
overriding crontab to rotate all logs on schedule

### DIFF
--- a/recipes-extended/cronie/cronie/crontab
+++ b/recipes-extended/cronie/cronie/crontab
@@ -1,0 +1,15 @@
+# /etc/crontab: system-wide crontab
+# Unlike any other crontab you don't have to run the `crontab'
+# command to install the new version when you edit this file
+# and files in /etc/cron.d. These files also have username fields,
+# that none of the other crontabs do.
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+#m 		h 		dom		mon 	dow 	user 	command
+*/10	*       *       *       *       root    /usr/sbin/logrotate /etc/logrotate.conf > /wigwag/log/cron-logrotate.log 2>&1
+1		*		*		*		*		root 	cd / && run-parts /etc/cron.hourly
+30		7		*		*		*		root 	cd / && run-parts /etc/cron.daily
+42		7		*		*		7		root 	cd / && run-parts /etc/cron.weekly
+55		7		1		*		*		root 	cd / && run-parts /etc/cron.monthly

--- a/recipes-extended/cronie/cronie_%.bbappend
+++ b/recipes-extended/cronie/cronie_%.bbappend
@@ -1,0 +1,2 @@
+#prepend to take precedence over poky/meta
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
This pull request needs to be cherry-picked into 1.0.0.  Log files are not being rotated on the build.  This pull request fixes that by having crontrab call logrotate every 10 minutes.  It has been tested against 1.0.0 but not against dev.