### PR TITLE
Work around a signing bug in Yocto

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -101,5 +101,5 @@ export SSH_AUTH_SOCK
 
 # This is a workaround for a bug in Yocto that sometimes causes the following warning to appear:
 # u-boot-1_2018.07-r0 do_concat_dtb: Failure while adding public key to u-boot binary. Verified boot won't be available.
-# See https://notred.atlassian.net/browse/AV-222 for more details
+# This is due to rm_work deleting the $DEPLOYDIR, which do_concat_dtb depends on.
 RM_WORK_EXCLUDE += "u-boot"


### PR DESCRIPTION
A missing dependency in Yocto causes u-boot dtb concatenation to fail
sometimes.  See https://notred.atlassian.net/browse/AV-222 for more
details.  A patch to fix the root cause will be upstreamed.