### PR TITLE
Start script to monitor the IP lease

### DIFF
--- a/recipes-wigwag/wwrelay-utils/wwrelay-utils/wwrelay
+++ b/recipes-wigwag/wwrelay-utils/wwrelay-utils/wwrelay
@@ -188,7 +188,7 @@ start(){
 
 		# Make sure edge-core is running all time. Start a script to monitor edge-core until maestro implements this feature
 		/wigwag/wwrelay-utils/debug_scripts/run_mbed_edge_core.sh >& /wigwag/log/run_mbed_edge_core.log &
-
+		/wigwag/wwrelay-utils/debug_scripts/monitor-acquire-new-lease.sh >& /wigwag/log/acquireNewLease.log &
 		monitor_edge_core
 		# if [ -d /userdata/mbed ]; then
 		# 	_log "Detected edge-gw. Reading edge eeprom..."


### PR DESCRIPTION
PELEDGE19-423 reports that gateway on iotlab network in Austin constantly
drops out of network. wwrelay init script will start a script to monitor
the IP and acquire new lease when gateway loses connectivity