### PR TITLE
set boot partition to a fixed size

### DIFF
--- a/recipes-core/ww-console-image-initramfs-init/files/initramfs-init-script.sh
+++ b/recipes-core/ww-console-image-initramfs-init/files/initramfs-init-script.sh
@@ -1352,7 +1352,7 @@ Strategy_UGpartition(){
 		1) expectedsize=$BootPartitionOrginalSize;
 		#
 		;;
-		2) expectedsize=52;
+		2) expectedsize=128;
 		#
 		;;	
 	esac

--- a/wic/console-image.wks
+++ b/wic/console-image.wks
@@ -2,7 +2,7 @@
 # long-description: Creates a partitioned SD card image for use with
 # Raspberry Pi. Boot files are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 128
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --fixed-size 128
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label factory --align 4096 --size 2048
 part /upgrade --ondisk mmcblk0 --fstype=ext4 --label upgrade --size 2048
 part /user --ondisk mmcblk0 --fstype=ext4 --label user --size 1024


### PR DESCRIPTION
Yocto likes to add padding to a partition unless the --fixed-size
parameter is used in the WKS specification.

The same size must also be reflected in the initramfs script so that
the partition schema is correctly recognized for the purposes of
boot partition upgrade.