### PR TITLE
Start relay term monitoring script

### DIFF
--- a/recipes-wigwag/wwrelay-utils/files/logrotate_directives/monitor_relay_term
+++ b/recipes-wigwag/wwrelay-utils/files/logrotate_directives/monitor_relay_term
@@ -1,0 +1,7 @@
+/wigwag/log/monitorRelayTerm.log {
+rotate 1
+size 1M
+nodateext
+copytruncate
+missingok
+}

--- a/recipes-wigwag/wwrelay-utils/wwrelay-utils/wwrelay
+++ b/recipes-wigwag/wwrelay-utils/wwrelay-utils/wwrelay
@@ -189,7 +189,7 @@ start(){
 		# Make sure edge-core is running all time. Start a script to monitor edge-core until maestro implements this feature
 		/wigwag/wwrelay-utils/debug_scripts/run_mbed_edge_core.sh >& /wigwag/log/run_mbed_edge_core.log &
 		/wigwag/wwrelay-utils/debug_scripts/monitor-acquire-new-lease.sh >& /wigwag/log/acquireNewLease.log &
-		/wigwag/wwrelay-utils/debug_scripts/monitor_relay_term.sh &
+		/wigwag/wwrelay-utils/debug_scripts/monitor_relay_term.sh >& /wigwag/log/monitorRelayTerm.log &
 		monitor_edge_core
 		# if [ -d /userdata/mbed ]; then
 		# 	_log "Detected edge-gw. Reading edge eeprom..."


### PR DESCRIPTION
Had to separate the edge-core and relay-term monitoring script as one was blocking the other.