### PR TITLE
Modified services and configs to re-route traffic through edge-proxy

### DIFF
--- a/recipes-wigwag/devicedb/devicedb_0.0.12.bb
+++ b/recipes-wigwag/devicedb/devicedb_0.0.12.bb
@@ -12,7 +12,7 @@ file://devicedb \
 "
 
 SRCREV_FORMAT = "ddb"
-SRCREV_ddb = "cbc730dde216150ac8706b7509dea40babd1832f"
+SRCREV_ddb = "d24df289ab24a035ebf64d2ed27a2d531a2319da"
 GO_IMPORT = "github.com/armPelionEdge/devicedb/"
 
 DEPENDS = ""

--- a/recipes-wigwag/maestro/maestro/rpi3/devicedb.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicedb.template.conf
@@ -165,7 +165,7 @@ cloud:
     # effectively ignored. In this example, the TLS certificate uses a wildcard
     # certificate so the server name provided in the certificate will not
     # match the domain name of the host to which this node is connecting.
-    uri: wss://{{ARCH_GW_SERVICES_RESRC}}/devicedb/sync
+    uri: ws://gateways.local:8080/devicedb/sync
 
     # Starting in version 1.3.0 of devicedb a seperate host name, port, and certificate
     # name can be specified for historical data forwarding. This is to allow decoupling
@@ -182,8 +182,8 @@ cloud:
     # historyID: "*.wigwag.io"
     # historyHost and historyPort may be ommitted. In this case historyHost and
     # historyPort are set to the normal cloud host and port
-    historyURI: {{ARCH_GW_SERVICES_URL}}/relay-history/history
-    alertsURI: {{ARCH_GW_SERVICES_URL}}/relay-alerts/alerts
+    historyURI: http://gateways.local:8080/relay-history/history
+    alertsURI: http://gateways.local:8080/relay-alerts/alerts
 
 # The TLS options specify file paths to PEM encoded SSL certificates and keys
 # All connections between database nodes use TLS to identify and authenticate
@@ -198,7 +198,8 @@ cloud:
 # node but does need to verify the database node's server certificate against
 # the same root certificate chain.
 # **REQUIRED**
-tls:
+nodeid: {{ARCH_DEVICE_ID}}
+#tls:
     # If using a single certificate for both client and server authentication
     # then it is specified using the certificate and key options as shown below
     # If using seperate client and server certificates then uncomment the options
@@ -212,17 +213,17 @@ tls:
     # key: path/to/key.pem
 
     # A PEM encoded 'client' type certificate
-    clientCertificate: {{SSL_CERTS_PATH}}/client.cert.pem
+    #clientCertificate: {{SSL_CERTS_PATH}}/client.cert.pem
 
     # A PEM encoded key corresponding to the specified client certificate
-    clientKey: {{SSL_CERTS_PATH}}/client.key.pem
+    #clientKey: {{SSL_CERTS_PATH}}/client.key.pem
 
     # A PEM encoded 'server' type certificate
-    serverCertificate: {{SSL_CERTS_PATH}}/server.cert.pem
+    #serverCertificate: {{SSL_CERTS_PATH}}/server.cert.pem
 
     # A PEM encoded key corresponding to the specified server certificate
-    serverKey: {{SSL_CERTS_PATH}}/server.key.pem
+    #serverKey: {{SSL_CERTS_PATH}}/server.key.pem
 
     # A PEM encoded certificate chain that can be used to verify the previous
     # certificates
-    rootCA: {{SSL_CERTS_PATH}}/ca-chain.cert.pem
+    #rootCA: {{SSL_CERTS_PATH}}/ca-chain.cert.pem

--- a/recipes-wigwag/maestro/maestro/rpi3/devicedb.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicedb.template.conf
@@ -165,7 +165,7 @@ cloud:
     # effectively ignored. In this example, the TLS certificate uses a wildcard
     # certificate so the server name provided in the certificate will not
     # match the domain name of the host to which this node is connecting.
-    uri: ws://gateways.local:8080/devicedb/sync
+    uri: ws://{{FOG_PROXY_ADDR}}/devicedb/sync
 
     # Starting in version 1.3.0 of devicedb a seperate host name, port, and certificate
     # name can be specified for historical data forwarding. This is to allow decoupling
@@ -182,8 +182,8 @@ cloud:
     # historyID: "*.wigwag.io"
     # historyHost and historyPort may be ommitted. In this case historyHost and
     # historyPort are set to the normal cloud host and port
-    historyURI: http://gateways.local:8080/relay-history/history
-    alertsURI: http://gateways.local:8080/relay-alerts/alerts
+    historyURI: http://{{FOG_PROXY_ADDR}}/relay-history/history
+    alertsURI: http://{{FOG_PROXY_ADDR}}/relay-alerts/alerts
 
 # The TLS options specify file paths to PEM encoded SSL certificates and keys
 # All connections between database nodes use TLS to identify and authenticate

--- a/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
@@ -1,32 +1,9 @@
 {
     "modulesDirectory": "/wigwag/etc/devicejs/modules",
     "port": 8081,
-    "cloudAddress": "{{ARCH_GW_SERVICES_URL}}/devicejs/socket.io",
+    "cloudAddress": "http://gateways.local:8080/devicejs/socket.io",
+    "nodeID": "{{ARCH_DEVICE_ID}}",
     "databaseConfig": {
-        "uri": "https://127.0.0.1:{{LOCAL_DEVICEDB_PORT}}",
-        "https": {
-            "ca": [
-                "{{SSL_CERTS_PATH}}/ca.cert.pem",
-                "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
-            ]
-        }
-    },
-    "https": {
-        "server": {
-            "key": "{{SSL_CERTS_PATH}}/server.key.pem",
-            "cert": "{{SSL_CERTS_PATH}}/server.cert.pem",
-            "ca": [
-                "{{SSL_CERTS_PATH}}/ca.cert.pem",
-                "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
-            ]
-        },
-        "client": {
-            "key": "{{SSL_CERTS_PATH}}/client.key.pem",
-            "cert": "{{SSL_CERTS_PATH}}/client.cert.pem",
-            "ca": [
-                "{{SSL_CERTS_PATH}}/ca.cert.pem",
-                "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
-            ]
-        }
+        "uri": "http://127.0.0.1:{{LOCAL_DEVICEDB_PORT}}"
     }
 }

--- a/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
@@ -1,7 +1,7 @@
 {
     "modulesDirectory": "/wigwag/etc/devicejs/modules",
     "port": 8081,
-    "cloudAddress": "http://gateways.local:8080/devicejs/socket.io",
+    "cloudAddress": "http://{{FOG_PROXY_ADDR}}/devicejs/socket.io",
     "nodeID": "{{ARCH_DEVICE_ID}}",
     "databaseConfig": {
         "uri": "http://127.0.0.1:{{LOCAL_DEVICEDB_PORT}}"

--- a/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
+++ b/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
@@ -46,8 +46,8 @@ var_defs:
    - key: "UPGRADE_VERSIONS_FILE"
      value: "/mnt/.overlay/upgrade/wigwag/etc/versions.json"
 devicedb_conn_config:
-    devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
-    devicedb_prefix: "maestro.configs" #default prefix
+    devicedb_uri: "http://localhost:{{LOCAL_DEVICEDB_PORT}}" #default uri
+    devicedb_prefix: "configs.device" #default prefix
     devicedb_bucket: "lww" #default bucket
     relay_id: "{{ARCH_DEVICE_ID}}" #default relay id  
 mdns:

--- a/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
+++ b/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
@@ -78,11 +78,13 @@ symphony:
     disable_sys_stats: true
     sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
     sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
-    client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
-    client_key: "{{ARCH_CLIENT_KEY_PEM}}"
-    host: "{{ARCH_GW_SERVICES_RESRC}}"
-    url_logs: "{{ARCH_GW_SERVICES_URL}}/relay-logs/logs"
-    url_stats: "{{ARCH_GW_SERVICES_URL}}/relay-stats/stats_obj"
+    #client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
+    #client_key: "{{ARCH_CLIENT_KEY_PEM}}"
+    no_tls: true
+    host: "gateways.local"
+    url_logs: "http://gateways.local:8080/relay-logs/logs"
+    url_stats: "http://gateways.local:8080/relay-stats/stats_obj"
+    send_time_threshold: 120000       # set the send time threshold to 2 minutes
     # port: "{{ARCH_RELAY_SERVICES_PORT}}"
 targets:
    - file: "/wigwag/log/devicejs.log"

--- a/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
+++ b/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
@@ -29,10 +29,10 @@ var_defs:
      value: "/wigwag/devicejs-ng"
    - key: "DEVJS_CORE_MODULES"
      value: "/wigwag/devicejs-core-modules"
+   - key: "FOG_PROXY_ADDR"
+     value: "gateways.local:8080"
    - key: "MAESTRO_RUNNER_DIR"
      value: "/wigwag/devicejs-core-modules/maestroRunner"
-   - key: "SSL_CERTS_PATH"
-     value: "/userdata/edge_gw_config/.ssl"
    - key: "LOCAL_DEVICEDB_PORT"
      value: 9000
    - key: "LOCAL_DATABASE_STORAGE_DIRECTORY"
@@ -49,8 +49,7 @@ devicedb_conn_config:
     devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
     devicedb_prefix: "maestro.configs" #default prefix
     devicedb_bucket: "lww" #default bucket
-    relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
-    ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name     
+    relay_id: "{{ARCH_DEVICE_ID}}" #default relay id  
 mdns:
   # disable: true
   static_records:
@@ -82,8 +81,8 @@ symphony:
     #client_key: "{{ARCH_CLIENT_KEY_PEM}}"
     no_tls: true
     host: "gateways.local"
-    url_logs: "http://gateways.local:8080/relay-logs/logs"
-    url_stats: "http://gateways.local:8080/relay-stats/stats_obj"
+    url_logs: "http://{{FOG_PROXY_ADDR}}/relay-logs/logs"
+    url_stats: "http://{{FOG_PROXY_ADDR}}/relay-stats/stats_obj"
     send_time_threshold: 120000       # set the send time threshold to 2 minutes
     # port: "{{ARCH_RELAY_SERVICES_PORT}}"
 targets:
@@ -131,27 +130,6 @@ static_file_generators:
    - name: "radioProfile"
      template_file: "/wigwag/etc/template/radioProfile.template.json"
      output_file: "/wigwag/devicejs-core-modules/rsmi/radioProfile.config.json"
-   - name: "ca_pem"
-     template: "{{ARCH_CA_CERT_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/ca.cert.pem"
-   - name: "intermediate_pem"
-     template: "{{ARCH_INTERMEDIATE_CERT_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
-   - name: "client_key"
-     template: "{{ARCH_CLIENT_KEY_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/client.key.pem"
-   - name: "client_cert"
-     template: "{{ARCH_CLIENT_CERT_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/client.cert.pem"
-   - name: "server_key"
-     template: "{{ARCH_SERVER_KEY_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/server.key.pem"
-   - name: "server_cert"
-     template: "{{ARCH_SERVER_CERT_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/server.cert.pem"
-   - name: "ca_chain"
-     template: "{{ARCH_CA_CHAIN_CERT_PEM}}"
-     output_file: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem"
 container_templates:
    - name: "deviceJS_process"
      immutable: true  # don't store in DB

--- a/recipes-wigwag/maestro/maestro/rpi3/relayTerm.template.json
+++ b/recipes-wigwag/maestro/maestro/rpi3/relayTerm.template.json
@@ -1,6 +1,6 @@
 {
-	"cloud": "{{ARCH_GW_SERVICES_URL}}/relay-term",
+	"cloud": "http://gateways.local:8080/relay-term",
 	"noValidate": true,
-	"certificate": "{{SSL_CERTS_PATH}}/client.cert.pem",
-	"key": "{{SSL_CERTS_PATH}}/client.key.pem"
+	"certificate": "",
+	"key": ""
 }

--- a/recipes-wigwag/maestro/maestro/rpi3/relayTerm.template.json
+++ b/recipes-wigwag/maestro/maestro/rpi3/relayTerm.template.json
@@ -1,5 +1,5 @@
 {
-	"cloud": "http://gateways.local:8080/relay-term",
+	"cloud": "http://{{FOG_PROXY_ADDR}}/relay-term",
 	"noValidate": true,
 	"certificate": "",
 	"key": ""

--- a/recipes-wigwag/maestro/maestro_0.0.1.inc
+++ b/recipes-wigwag/maestro/maestro_0.0.1.inc
@@ -54,7 +54,7 @@ file://maestro-watcher.path \
 "
 
 SRCREV_FORMAT="m"
-SRCREV_m="d6ab0da4238bb4d8b767db3f70af71db909fae1c"
+SRCREV_m="458a91f7278e8431ab446c3b751500e2b390c262"
 
 GO_IMPORT = "github.com/armPelionEdge/maestro"
 


### PR DESCRIPTION
Changing Devicedb, ~Devicejs~, Relay-term, maestro config so that all services on raspberry Pi can talk through edge-proxy.
Tested functionality of relay-term, maestro by running edge-proxy on raspberry Pi.
~Needs further testing when edge-proxy is added to the meta-pelion-edge repo.~