### PR TITLE
Pinned version of 'pyopenssl' for 'mbed-fcc' recipe.

### DIFF
--- a/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
+++ b/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
@@ -27,6 +27,7 @@ do_configure () {
 	export PYTHONPATH=`pwd`/recipe-sysroot-native/user/lib/python2.7
 	export PATH=$PYTHONPATH:$PATH
 	python -m pip install pip==19.3.1
+	python -m pip install pyopenssl==19.1.0
 	python -m pip install mbed-cli click==7.0 requests
 }
 


### PR DESCRIPTION
Experienced an issue similar to this one after the python module was updated to v20.0.0:
https://github.com/pypa/pipenv/issues/4548#issuecomment-735992788

Without this pin, building against the 'dev' branch is currently broken.


CI build link incoming once it completes, but have verified on my local system that this seems to resolve the problem.