### PR TITLE
Relay-term: Removed meta-nodejs, use yocto's native nodejs, removed dependency on global-node-modules

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -19,6 +19,5 @@ BBLAYERS ?= " \
     ##OEROOT##/meta-virtualization \
     ##OEROOT##/meta-raspberrypi \
     ##OEROOT##/meta-security \
-    ##OEROOT##/meta-nodejs \
     ##OEROOT##/meta-mbed-edge \
 "

--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -155,7 +155,7 @@ WIGWAG_STUFF = " \
     deviceos-users \
     wwrelay-utils \
     fluentbit \
-    relay-term-dbg \
+    relay-term \
 "
 
 IMAGE_INSTALL += " \

--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -155,7 +155,7 @@ WIGWAG_STUFF = " \
     deviceos-users \
     wwrelay-utils \
     fluentbit \
-    relay-term \
+    relay-term-dbg \
 "
 
 IMAGE_INSTALL += " \

--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -155,6 +155,7 @@ WIGWAG_STUFF = " \
     deviceos-users \
     wwrelay-utils \
     fluentbit \
+    relay-term \
 "
 
 IMAGE_INSTALL += " \

--- a/recipes-wigwag/relay-term/files/npm-shrinkwrap.json
+++ b/recipes-wigwag/relay-term/files/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "relay-term",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
+    "node-pty": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.9.0.tgz",
+      "integrity": "sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==",
+      "requires": {
+        "nan": "^2.14.0"
+      }
+    },
+    "ws": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+    }
+  }
+}

--- a/recipes-wigwag/relay-term/files/npm-shrinkwrap.json
+++ b/recipes-wigwag/relay-term/files/npm-shrinkwrap.json
@@ -14,13 +14,12 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
-    "node-pty-prebuilt-multiarch": {
+    "node-pty": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.9.0.tgz",
-      "integrity": "sha512-n5LkPEuBwI+S2GgDk+IEByoVZClYFQGfp1b6dbMMEln7e43ikF8LZVi3vxpLXVq1rnS8t54YOnMB7HSB4jw8Tg==",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.9.0.tgz",
+      "integrity": "sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==",
       "requires": {
-        "nan": "^2.14.0",
-        "prebuild-install": "^5.2.5"
+        "nan": "^2.14.0"
       }
     },
     "ws": {

--- a/recipes-wigwag/relay-term/files/npm-shrinkwrap.json
+++ b/recipes-wigwag/relay-term/files/npm-shrinkwrap.json
@@ -14,12 +14,13 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
-    "node-pty": {
+    "node-pty-prebuilt-multiarch": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.9.0.tgz",
-      "integrity": "sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==",
+      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.9.0.tgz",
+      "integrity": "sha512-n5LkPEuBwI+S2GgDk+IEByoVZClYFQGfp1b6dbMMEln7e43ikF8LZVi3vxpLXVq1rnS8t54YOnMB7HSB4jw8Tg==",
       "requires": {
-        "nan": "^2.14.0"
+        "nan": "^2.14.0",
+        "prebuild-install": "^5.2.5"
       }
     },
     "ws": {

--- a/recipes-wigwag/relay-term/files/pelion-relay-term.service
+++ b/recipes-wigwag/relay-term/files/pelion-relay-term.service
@@ -5,7 +5,6 @@ After=maestro.service
 [Service]
 Restart=always
 RestartSec=5s
-Environment=NODE_PATH=/wigwag/devicejs-core-modules/node_modules
 ExecStart=/usr/bin/node /wigwag/wigwag-core-modules/relay-term/src/index.js start /wigwag/wigwag-core-modules/relay-term/config/config.json
 
 [Install]

--- a/recipes-wigwag/relay-term/files/relay-term-watcher.path
+++ b/recipes-wigwag/relay-term/files/relay-term-watcher.path
@@ -2,7 +2,7 @@
 Description=Monitor the changes to identity.json file and restart relay-term
 
 [Path]
-PathChanged=/userdata/edge_gw_config/.ssl/client.cert.pem
+PathChanged=/wigwag/wigwag-core-modules/relay-term/config/config.json
 Unit=relay-term-watcher.service
 
 [Install]

--- a/recipes-wigwag/relay-term/relay-term_0.0.1.bb
+++ b/recipes-wigwag/relay-term/relay-term_0.0.1.bb
@@ -5,19 +5,22 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 RT_SERVICE_FILE = "pelion-relay-term.service"
 PR = "r1"
+S = "${WORKDIR}/git"
 
 FILES_${PN} += "\
     ${systemd_system_unitdir}/${PN}-watcher.service\
     ${systemd_system_unitdir}/${PN}-watcher.path\
     "
 
-SRC_URI = "file://${RT_SERVICE_FILE} \
+SRC_URI = "git://git@github.com/armPelionEdge/edge-node-modules.git;protocol=https \
+file://${RT_SERVICE_FILE} \
 file://${PN}-watcher.service \
 file://${PN}-watcher.path \
 "
 
-inherit pkgconfig systemd
+SRCREV = "beb52f9dde785aaa7b3eff93fc8dbbd4f79486c4"
 
+inherit pkgconfig systemd
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "${RT_SERVICE_FILE} \
@@ -26,16 +29,24 @@ ${PN}-watcher.path"
 
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
-
+DEPENDS ="nodejs"
 RDEPENDS_${PN} += "bash"
 
+do_compile() {
+    cd ${S}/relay-term
+    cp devicejs.json package.json
+    npm install
+}
 
 do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 755 ${WORKDIR}/${RT_SERVICE_FILE} ${D}${systemd_system_unitdir}/${RT_SERVICE_FILE}
     install -m 755 ${WORKDIR}/${PN}-watcher.service ${D}${systemd_system_unitdir}/${PN}-watcher.service
     install -m 755 ${WORKDIR}/${PN}-watcher.path ${D}${systemd_system_unitdir}/${PN}-watcher.path
+
+    install -d ${D}/wigwag/devicejs-core-modules/node_modules
+    install -m 0755 ${S}/node_modules ${D}/wigwag/devicejs-core-modules/node_modules
+
+    install -d ${D}/wigwag/wigwag-core-modules
+    install -m 0755 ${S}/relay-term ${D}/wigwag/wigwag-core-modules/relay-term
 }
-
-
-

--- a/recipes-wigwag/relay-term/relay-term_0.0.1.bb
+++ b/recipes-wigwag/relay-term/relay-term_0.0.1.bb
@@ -43,4 +43,12 @@ do_install() {
 
     install -d ${D}/wigwag/wigwag-core-modules
     cp -r ${S} ${D}/wigwag/wigwag-core-modules/relay-term
+
+    # Reference - https://www.yoctoproject.org/docs/3.0.1/dev-manual/dev-manual.html#npm-package-creation-requirements
+    # devtool cannot detect native libraries in module dependencies. Consequently, you must manually add packages to your recipe.
+    # While deploying NPM packages, devtool cannot determine which dependent packages are missing on the target (e.g. the node runtime nodejs).
+    # Consequently, you need to find out what files are missing and be sure they are on the target.
+
+    install -d ${D}/wigwag/wigwag-core-modules/relay-term/node_modules/node-pty/build
+    cp -r ${S}/../../npm-build/lib/node_modules/relay-term/node_modules/node-pty/build/* ${D}/wigwag/wigwag-core-modules/relay-term/node_modules/node-pty/build/
 }

--- a/recipes-wigwag/relay-term/relay-term_0.0.1.bb
+++ b/recipes-wigwag/relay-term/relay-term_0.0.1.bb
@@ -11,14 +11,13 @@ FILES_${PN} += "\
     ${systemd_system_unitdir}/${PN}-watcher.service\
     ${systemd_system_unitdir}/${PN}-watcher.path\
     /wigwag/wigwag-core-modules/*\
-    /wigwag/devicejs-core-modules/*\
     "
 
 SRC_URI = "git://git@github.com/armPelionEdge/edge-node-modules.git;protocol=https \
 npmsw://${THISDIR}/files/npm-shrinkwrap.json \
 file://${RT_SERVICE_FILE} \
-file://${PN}-watcher.service \
-file://${PN}-watcher.path \
+file://${BPN}-watcher.service \
+file://${BPN}-watcher.path \
 "
 
 SRCREV = "b72acd69a13c4cb474e6ff96eb78bb9de7e99c45"
@@ -32,7 +31,7 @@ ${PN}-watcher.path"
 
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
-DEPENDS ="nodejs"
+DEPENDS ="nodejs-native libuv"
 RDEPENDS_${PN} += "bash nodejs"
 
 do_install() {
@@ -41,9 +40,6 @@ do_install() {
     install -m 755 ${WORKDIR}/${RT_SERVICE_FILE} ${D}${systemd_system_unitdir}/${RT_SERVICE_FILE}
     install -m 755 ${WORKDIR}/${PN}-watcher.service ${D}${systemd_system_unitdir}/${PN}-watcher.service
     install -m 755 ${WORKDIR}/${PN}-watcher.path ${D}${systemd_system_unitdir}/${PN}-watcher.path
-
-    install -d ${D}/wigwag/devicejs-core-modules/node_modules
-    cp -r ${S}/node_modules ${D}/wigwag/devicejs-core-modules/node_modules
 
     install -d ${D}/wigwag/wigwag-core-modules
     cp -r ${S} ${D}/wigwag/wigwag-core-modules/relay-term

--- a/recipes-wigwag/relay-term/relay-term_0.0.1.bb
+++ b/recipes-wigwag/relay-term/relay-term_0.0.1.bb
@@ -5,22 +5,25 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 RT_SERVICE_FILE = "pelion-relay-term.service"
 PR = "r1"
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/git/relay-term"
 
 FILES_${PN} += "\
     ${systemd_system_unitdir}/${PN}-watcher.service\
     ${systemd_system_unitdir}/${PN}-watcher.path\
+    /wigwag/wigwag-core-modules/*\
+    /wigwag/devicejs-core-modules/*\
     "
 
 SRC_URI = "git://git@github.com/armPelionEdge/edge-node-modules.git;protocol=https \
+npmsw://${THISDIR}/files/npm-shrinkwrap.json \
 file://${RT_SERVICE_FILE} \
 file://${PN}-watcher.service \
 file://${PN}-watcher.path \
 "
 
-SRCREV = "beb52f9dde785aaa7b3eff93fc8dbbd4f79486c4"
+SRCREV = "b72acd69a13c4cb474e6ff96eb78bb9de7e99c45"
 
-inherit pkgconfig systemd
+inherit pkgconfig systemd npm
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "${RT_SERVICE_FILE} \
@@ -30,23 +33,18 @@ ${PN}-watcher.path"
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
 DEPENDS ="nodejs"
-RDEPENDS_${PN} += "bash"
-
-do_compile() {
-    cd ${S}/relay-term
-    cp devicejs.json package.json
-    npm install
-}
+RDEPENDS_${PN} += "bash nodejs"
 
 do_install() {
+    cd ${S}
     install -d ${D}${systemd_system_unitdir}
     install -m 755 ${WORKDIR}/${RT_SERVICE_FILE} ${D}${systemd_system_unitdir}/${RT_SERVICE_FILE}
     install -m 755 ${WORKDIR}/${PN}-watcher.service ${D}${systemd_system_unitdir}/${PN}-watcher.service
     install -m 755 ${WORKDIR}/${PN}-watcher.path ${D}${systemd_system_unitdir}/${PN}-watcher.path
 
     install -d ${D}/wigwag/devicejs-core-modules/node_modules
-    install -m 0755 ${S}/node_modules ${D}/wigwag/devicejs-core-modules/node_modules
+    cp -r ${S}/node_modules ${D}/wigwag/devicejs-core-modules/node_modules
 
     install -d ${D}/wigwag/wigwag-core-modules
-    install -m 0755 ${S}/relay-term ${D}/wigwag/wigwag-core-modules/relay-term
+    cp -r ${S} ${D}/wigwag/wigwag-core-modules/relay-term
 }


### PR DESCRIPTION
Also added shrinkwrap.json as its required to successfully build the package. npm-shrinkwrap.json is also part of the relay-term source code, but was not able to use that so had to add it here.