### PR TITLE
Streamlined the startup sequence inorder to remove the cyclic dependency

### DIFF
--- a/recipes-connectivity/identity-tool/files/wait-for-pelion-identity.service
+++ b/recipes-connectivity/identity-tool/files/wait-for-pelion-identity.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Wait for a connection to Pelion and create credentials
-Requires=edge-core.service
+Wants=edge-core.service
 After=edge-core.service
-Before=edge-proxy.service
 
 [Service]
 Restart=on-failure

--- a/recipes-containers/kubelet/files/kubelet.service
+++ b/recipes-containers/kubelet/files/kubelet.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kubelet
-Requires=wait-for-pelion-identity.service
-Requires=edge-proxy.service
+Wants=edge-proxy.service
+After=edge-proxy.service
 
 [Service]
 Restart=always

--- a/recipes-extended/fluentbit/files/td-agent-bit.service
+++ b/recipes-extended/fluentbit/files/td-agent-bit.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Fast log collector
+Wants=edge-proxy.service
 After=edge-proxy.service
 
 [Service]

--- a/recipes-wigwag/edge-proxy/files/edge-proxy.service
+++ b/recipes-wigwag/edge-proxy/files/edge-proxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tunneling Proxy for gateways
-Requires=wait-for-pelion-identity.service
+Wants=wait-for-pelion-identity.service
 After=wait-for-pelion-identity.service
 
 [Service]

--- a/recipes-wigwag/maestro/maestro/maestro.service
+++ b/recipes-wigwag/maestro/maestro/maestro.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Maestro: Network, Config, DeviceJS manager
+Wants=edge-proxy.service
+After=edge-proxy.service
 
 [Service]
 Restart=always

--- a/recipes-wigwag/relay-term/files/pelion-relay-term.service
+++ b/recipes-wigwag/relay-term/files/pelion-relay-term.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=relay terminal for remote terminals in pelion cloud
+Wants=maestro.service
 After=maestro.service
 
 [Service]


### PR DESCRIPTION
According to https://www.freedesktop.org/software/systemd/man/systemd.unit.html, `Requires` builds a stronger dependency vs `Wants`. For instance, currently we "requires" edge-core in wait-for-pelion-identity. So if edge-core restarts, wait-for-pelion-identity is stopped and restarted by systemd. And as other services also requires wait-for-pelion-identity, edge-proxy is stopped and restarted, similarly maestro, kubelet and relay-term. 

So I ran into this scenario where maestro started crashing edge-core (due to version mismatch) and as edge-core restarted, everything restarted and maestro again crashed edge-core and so on.. the dormammu time loop.. 

In order to break this cyclic dependeny, the proposal is to use `Wants`, that way even though the service is crashed, it wont force the other service to restart. But at boot time they know their order and dependency so its good to state that in the service file. 

Proposed startup sequence - 

network-online ---> edge-core ---> wait-for-pelion-identity ---> edge-proxy ---> maestro (starts devicedb) ---> relay-term
__________________________________________________________----> fluentbit
__________________________________________________________----> kubelet

edge-proxy, maestro, kubelet are also configured with path unit file and they are watching the `identity.json` file. If that file changes then those services will be restarted. This is helpful in the scenario when wait-for-pelion-identity is continously failing for instance at boot time when the system is taking time to acquire IP, then once the identity.json is written all the services dependent on that are restarted.

