### PR TITLE
systemd-conf - add the flags in journal.conf for FSS feature

### DIFF
--- a/recipes-core/systemd/systemd-conf%.bbappend
+++ b/recipes-core/systemd/systemd-conf%.bbappend
@@ -1,6 +1,2 @@
-SUMMARY = "adds flags to journeld.conf in a simmilar way to the method used by systemd-conf found in the systemd bitbake reciepe"
-do_install_append () {
-   sed -i -e 's/.*Storage.*/Storage=persistent/' ${D}${systemd_unitdir}/journald.conf.d/00-systemd-conf.conf
-   sed -i -e 's/.*SystemMaxUse.*/SystemMaxUse=64M/' ${D}${systemd_unitdir}/journald.conf.d/00-systemd-conf.conf
-   sed -i -e 's/.*Seal.*/Seal=yes/' ${D}${systemd_unitdir}/journald.conf.d/00-systemd-conf.conf
-}
+SUMMARY = "adds flags to journald.conf in a similar way to the method used by systemd-conf found in the systemd bitbake recipe"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/recipes-core/systemd/systemd-conf/00-systemd-conf.conf
+++ b/recipes-core/systemd/systemd-conf/00-systemd-conf.conf
@@ -1,0 +1,6 @@
+[Journal]
+ForwardToSyslog=yes
+RuntimeMaxUse=64M
+Storage=persistent
+SystemMaxUse=64M
+Seal=yes


### PR DESCRIPTION
sed doesn't work as the [original file](http://cgit.openembedded.org/openembedded-core/tree/meta/recipes-core/systemd/systemd-conf/journald.conf?h=dunfell&id=d87efd14ce0471135c0aa7fd7b5da2808acb9c76) do not contains the search strings. Adding a file which overwrites the default file. 