### PR TITLE
Update Go to 1.14.6

### DIFF
--- a/recipes-devtools/go/go-1.14.inc
+++ b/recipes-devtools/go/go-1.14.inc
@@ -1,7 +1,7 @@
 require go-common.inc
 
 GO_BASEVERSION = "1.14"
-GO_MINOR = ".4"
+GO_MINOR = ".6"
 PV .= "${GO_MINOR}"
 FILESEXTRAPATHS_prepend := "${FILE_DIRNAME}/go-${GO_BASEVERSION}:"
 
@@ -18,4 +18,4 @@ SRC_URI += "\
     file://0008-use-GOBUILDMODE-to-set-buildmode.patch \
 "
 SRC_URI_append_libc-musl = " file://0009-ld-replace-glibc-dynamic-linker-with-musl.patch"
-SRC_URI[main.sha256sum] = "7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584"
+SRC_URI[main.sha256sum] = "73fc9d781815d411928eccb92bf20d5b4264797be69410eac854babe44c94c09"


### PR DESCRIPTION
Update Go to 1.14.6 for https://github.com/golang/go/issues/39698

_Updated description from internal Jira ticket with more info ~@cmonr_

Go version is too old, 1.14.4.
it's very old.
Currently 1.14 branch is upto 1.14.14
- All patches include security fixes!
- There are also concurrency and memory handling bugs, too.