### PR TITLE
Fix license names to Apache-2.0

### DIFF
--- a/recipes-misc/path-set/path-set_0.0.1.bb
+++ b/recipes-misc/path-set/path-set_0.0.1.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Adds needed paths to the profile for Pelion Edge programs"
 
-LICENSE = "APACHE-2.0"
+LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = "file://pelionpath.sh"

--- a/recipes-misc/pelion-version/pelion-version_0.0.1.bb
+++ b/recipes-misc/pelion-version/pelion-version_0.0.1.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Adds the version number file for overfs updater"
 
-LICENSE = "APACHE-2.0"
+LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = "file://BUILDMMU.txt"


### PR DESCRIPTION
Fix license names to "Apache-2.0". It was written as "APACHE-2.0", which was unrecognized and yielding build warnings in Yocto.