### PR TITLE
Kubelet - removed the patch to version.sh as bash is added to DEPEDNS

### DIFF
--- a/recipes-containers/kubelet/kubelet_git.bb
+++ b/recipes-containers/kubelet/kubelet_git.bb
@@ -46,8 +46,6 @@ do_compile() {
   export TMPDIR="${GOTMPDIR}"
   # KUBE_GO_PACKAGE is expected to be set by the version.sh script
   export KUBE_GO_PACKAGE=${GO_IMPORT}
-  # sh doesn't like variable names with '::' in them. Replace all '::' occurrences with '_'
-  bash -c eval "$(cat ${GOPATH}/src/${GO_IMPORT}/hack/lib/version.sh | sed --expression 's/::/_/g')"
   echo "${GO} install -v -ldflags=\"$GO_RPATH $GO_LINKMODE -extldflags '$GO_EXTLDFLAGS' $(kube_version_ldflags)\" ${GO_PACKAGES}" > /tmp/gostuff
   ${GO} install -v -ldflags="$GO_RPATH $GO_LINKMODE -extldflags '$GO_EXTLDFLAGS' $(kube_version_ldflags)" ${GO_PACKAGES}
 }


### PR DESCRIPTION
This will fix the Argus's kubelet version bug. 