### PR TITLE
By default enabled persistent logging in journald - prerequiste for FSS feature

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -88,8 +88,9 @@ CHAGE_USERS_PARAMS = "chage -d0 root; "
 # from poky master branch (newer than dunfell) see file: tcmode-default.inc
 GOVERSION = "1.14%"
 
-#if persistant /var/log is desired, set the following to "no"
-VOLATILE_LOG_DIR = "yes"
+# if persistent /var/log is desired, set the following to "no"
+# persistent logging is required to enable Journald's Forware Secure Sealing (FSS) feature
+VOLATILE_LOG_DIR = "no"
 
 USER_CLASSES = "image-mklibs image-prelink"
 PATCHRESOLVE = "noop"


### PR DESCRIPTION
Have manually verified that our Journald configuration don't grow more than 64M - https://github.com/PelionIoT/meta-pelion-edge/blob/dev/recipes-core/systemd/systemd-conf/journald.conf#L5 

`journalctl --disk-usage` reports 72M but that is couting 8M of active journal file. So it never grows above 72M. 