### PR TITLE
[MERGE FOR HOTFIX] Fixed regression introduced due to Py2 support being officially dropped.

### DIFF
--- a/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
+++ b/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
@@ -23,7 +23,7 @@ FILES_${PN} = "/wigwag/wwrelay-utils/I2C/*"
 
 do_configure () {
 	cd ${S}
-	curl -k https://bootstrap.pypa.io/get-pip.py | python
+	curl -k https://bootstrap.pypa.io/2.7/get-pip.py | python
 	export PYTHONPATH=`pwd`/recipe-sysroot-native/user/lib/python2.7
 	export PATH=$PYTHONPATH:$PATH
 	python -m pip install pip==19.3.1


### PR DESCRIPTION
`manifest-pelion-edge` nightly builds on `master` started failing a few days ago when pip dropped support and backwards compatability for Python 2.

However, `mbed_fcc` was still always pulling the latest version of pip before downgrading. This caused it to pull an incompatible version and fail to build, with even the error handler failing to to the syntax change.

Fortunately, the pypa.io maintainers were kind enough to include a way to pull a specific version, which is all this commit does.


### NOTE

#### This PR targets the 2.1.1 release. Only merge on agreement that a 2.1.2 hotpatch release is needed.