### PR TITLE
Do not start kubelet when deviceID is null

### DIFF
--- a/recipes-containers/kubelet/files/launch-kubelet.sh
+++ b/recipes-containers/kubelet/files/launch-kubelet.sh
@@ -18,7 +18,7 @@
 # ----------------------------------------------------------------------------
 
 DEVICE_ID=`jq -r .deviceID /userdata/edge_gw_config/identity.json`
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]] || [[ $DEVICE_ID == null ]]; then
     echo "Unable to extract device ID from identity.json"
     exit 1
 fi


### PR DESCRIPTION
As kubelet service only look for `Wants=edge-proxy.service` and not `wait-for-pelion-identity`, it starts before identity.json is populated. Once Kubelet starts with deviceID=null, it throws error `node="null" not found` but doesn't exit. Hence, kubelet needs to be manually restarted after identity.json file is written and that's why we need 2 reboots for kubelet to register the node. 