### PR TITLE
Upgraded pe-util to 2.0.4 and added jq as RDEPENDS for services which are dependent on it

### DIFF
--- a/recipes-connectivity/identity-tool/identity-tool_0.0.1.bb
+++ b/recipes-connectivity/identity-tool/identity-tool_0.0.1.bb
@@ -9,7 +9,7 @@ file://wait-for-pelion-identity.service \
 "
 
 #SRCREV_FORMAT = "wwrelay-dss"
-SRCREV_pe-utils = "365c21002df48f310c286b21a01c496d31929df7"
+SRCREV_pe-utils = "810b73f3dcfd15a21b179bc58319d68f11aaa838"
 
 inherit pkgconfig gitpkgv systemd
 
@@ -24,7 +24,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r0"
 
 DEPENDS = ""
-RDEPENDS_${PN} += " bash curl"
+RDEPENDS_${PN} += " bash curl jq"
 
 RM_WORK_EXCLUDE += "${PN}"
 

--- a/recipes-containers/kubelet/kubelet_git.bb
+++ b/recipes-containers/kubelet/kubelet_git.bb
@@ -23,7 +23,7 @@ SRCREV = "83b266ae6939012883611d6dbda745f2490a67c4"
 PR = "r1"
 
 DEPENDS = "libseccomp bash-native"
-RDEPENDS_${PN} += " docker libseccomp cni bash"
+RDEPENDS_${PN} += " docker libseccomp cni bash jq"
 
 bindir = "/wigwag/system/bin"
 confdir = "/wigwag/system/var/lib/kubelet"

--- a/recipes-misc/info-tool/info-tool_2.0.0.bb
+++ b/recipes-misc/info-tool/info-tool_2.0.0.bb
@@ -8,7 +8,7 @@ git://git@github.com/armPelionEdge/pe-utils.git;protocol=ssh;name=pe-utils;dests
 "
 
 #SRCREV_FORMAT = "wwrelay-dss"
-SRCREV_pe-utils = "365c21002df48f310c286b21a01c496d31929df7"
+SRCREV_pe-utils = "810b73f3dcfd15a21b179bc58319d68f11aaa838"
 
 inherit pkgconfig gitpkgv 
 


### PR DESCRIPTION
jq is used by kubelet, edge-proxy and identity-tool.
This fixes the regression issue in identity-tool - endpoint-name is set as serial number in identity file