### PR TITLE
Fluentbit compilation with usrmerge distro feature

### DIFF
--- a/recipes-extended/fluentbit/files/0001-support-usrmerge.patch
+++ b/recipes-extended/fluentbit/files/0001-support-usrmerge.patch
@@ -1,0 +1,18 @@
+--- a/src/CMakeLists.txt	2021-01-29 18:53:08.207732784 +0200
++++ b/src/CMakeLists.txt	2021-01-30 11:05:22.091922360 +0200
+@@ -317,13 +317,13 @@ if(FLB_BINARY)
+   install(TARGETS fluent-bit-bin RUNTIME DESTINATION ${FLB_INSTALL_BINDIR})
+
+   # Detect init system, install upstart, systemd or init.d script
+-  if(IS_DIRECTORY /lib/systemd/system)
++  if(IS_DIRECTORY /usr/lib/systemd/system)
+     set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
+     configure_file(
+       "${PROJECT_SOURCE_DIR}/init/systemd.in"
+       ${FLB_SYSTEMD_SCRIPT}
+       )
+-    install(FILES ${FLB_SYSTEMD_SCRIPT} DESTINATION /lib/systemd/system)
++    install(FILES ${FLB_SYSTEMD_SCRIPT} DESTINATION /usr/lib/systemd/system)
+     install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR})
+   elseif(IS_DIRECTORY /usr/share/upstart)
+     set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")

--- a/recipes-extended/fluentbit/fluentbit_%.bbappend
+++ b/recipes-extended/fluentbit/fluentbit_%.bbappend
@@ -18,6 +18,7 @@ FILES_${PN} += "\
     "
 
 SRC_URI = "http://fluentbit.io/releases/1.3/fluent-bit-${PV}.tar.gz \
+            ${@bb.utils.contains('DISTRO_FEATURES','usrmerge','file://0001-support-usrmerge.patch','',d)} \
             file://${FB_PKG_NAME}.service \
             file://${FB_PKG_NAME}.conf \
             file://${FB_PKG_NAME}-watcher.service \


### PR DESCRIPTION
It seems like the fluentbit statically installs the service to /lib/systemd/system. However, with distros that have usrmerge feature enabled, this will not work, since nothing should be directly installed to /lib. This PR adds a patch that should install the service to correct location if usrmerge is enabled