### PR TITLE
Disabled maestro logging and removed the tail filter from fluenbit

### DIFF
--- a/recipes-extended/fluentbit/files/td-agent-bit.conf
+++ b/recipes-extended/fluentbit/files/td-agent-bit.conf
@@ -193,46 +193,6 @@
     Wildcard MESSAGE*
     Nest_under message_json
 
-@SET maestro_gw_logs_tag=maestro_gw_logs
-
-[INPUT]
-    Name            tail
-    Tag             ${maestro_gw_logs_tag}
-    path            /wigwag/log/maestro_gw.log
-[FILTER]
-    Name record_modifier
-    Match ${maestro_gw_logs_tag}
-    Whitelist_key log
-    Whitelist_key level
-    Record app_name maestro_gw_logs
-    Record type tail
-    Record level info
-[FILTER]
-    Name grep
-    Match ${maestro_gw_logs_tag}
-    Exclude log \<WARN\>
-[FILTER]
-    Name    modify
-    Match   ${maestro_gw_logs_tag}
-    Condition Key_value_matches  log \<WARN\>
-    Set level WARNING
-[FILTER]
-    Name    modify
-    Match   ${maestro_gw_logs_tag}
-    Condition Key_value_matches  log \<ERROR\>
-    Set level ERROR
-[FILTER]
-    Name    modify
-    Match   ${maestro_gw_logs_tag}
-    Condition Key_value_does_not_match  log \<WARN\>|\<ERROR\>
-    Set level TRACE
-[FILTER]
-    Name nest
-    Match ${maestro_gw_logs_tag}
-    Operation nest
-    Wildcard log*
-    Nest_under message_json
-
 @SET wait-for-pelion-identity_tag=wait-for-pelion-identity
 
 [INPUT]

--- a/recipes-wigwag/maestro/maestro/imx8mmevk/maestro-config-imx8mmevk.yaml
+++ b/recipes-wigwag/maestro/maestro/imx8mmevk/maestro-config-imx8mmevk.yaml
@@ -68,38 +68,6 @@ symphony: # symphony system management APIs
     url_logs: "http://{{FOG_PROXY_ADDR}}/relay-logs/logs"
     url_stats: "http://{{FOG_PROXY_ADDR}}/relay-stats/stats_obj"
     send_time_threshold: 120000       # set the send time threshold to 2 minutes
-targets:
-   - file: "/wigwag/log/maestro_gw.log"
-     rotate:
-         max_files: 4
-         max_file_size: 10000000  # 10MB max file size
-         max_total_size: 42000000
-         rotate_on_start: true
-     delim: "\n"
-     format_time: "[%ld:%d] "
-     format_level: "<%s> "
-     format_tag: "{%s} "
-     format_origin: "(%s) "
-     filters:
-       - levels: warn
-         format_pre: "\u001B[33m"    # yellow
-         format_post: "\u001B[39m"
-       - levels: error
-         format_pre: "\u001B[31m"    # red
-         format_post: "\u001B[39m"
-   - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
-     format_time: "\"timestamp\":%ld%03d, "
-     format_level: "\"level\":\"%s\", "
-     format_tag: "\"tag\":\"%s\", "
-     format_origin: "\"origin\":\"%s\", "
-     format_pre_msg: "\"text\":\""
-     format_post: "\"},"
-     flag_json_escape_strings: true
-     filters:
-       - levels: warn
-         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
-       - levels: error
-         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
 static_file_generators:
    - name: "devicedb"
      template_file: "/wigwag/etc/template/devicedb.template.conf"

--- a/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
+++ b/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
@@ -68,38 +68,6 @@ symphony: # symphony system management APIs
     url_logs: "http://{{FOG_PROXY_ADDR}}/relay-logs/logs"
     url_stats: "http://{{FOG_PROXY_ADDR}}/relay-stats/stats_obj"
     send_time_threshold: 120000       # set the send time threshold to 2 minutes
-targets:
-   - file: "/wigwag/log/maestro_gw.log"
-     rotate:
-         max_files: 4
-         max_file_size: 10000000  # 10MB max file size
-         max_total_size: 42000000
-         rotate_on_start: true
-     delim: "\n"
-     format_time: "[%ld:%d] "
-     format_level: "<%s> "
-     format_tag: "{%s} "
-     format_origin: "(%s) "
-     filters:
-       - levels: warn
-         format_pre: "\u001B[33m"    # yellow
-         format_post: "\u001B[39m"
-       - levels: error
-         format_pre: "\u001B[31m"    # red
-         format_post: "\u001B[39m"
-   - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
-     format_time: "\"timestamp\":%ld%03d, "
-     format_level: "\"level\":\"%s\", "
-     format_tag: "\"tag\":\"%s\", "
-     format_origin: "\"origin\":\"%s\", "
-     format_pre_msg: "\"text\":\""
-     format_post: "\"},"
-     flag_json_escape_strings: true
-     filters:
-       - levels: warn
-         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
-       - levels: error
-         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
 static_file_generators:
    - name: "devicedb"
      template_file: "/wigwag/etc/template/devicedb.template.conf"


### PR DESCRIPTION
This disables greaselib library being called in maestro. Might resolve the panic we are observing on imx8 board - Fatal error: sweep increased allocation count. 