### PR TITLE
Add relay-term to the lmp-image

### DIFF
--- a/meta-lmp-support/recipes-core/images/console-image-lmp.bb
+++ b/meta-lmp-support/recipes-core/images/console-image-lmp.bb
@@ -52,6 +52,7 @@ edge-proxy \
 maestro \
 devicedb \
 info-tool \
+relay-term \
 fluentbit \
 "
 


### PR DESCRIPTION
The issues with nodejs are now fixed, and the relay-term can be re-introduced