### PR TITLE
Generalize the patch libuv autoconf patch

### DIFF
--- a/recipes-wigwag/maestro/maestro/imx8mmevk/0003-build-with-autoconf.patch
+++ b/recipes-wigwag/maestro/maestro/imx8mmevk/0003-build-with-autoconf.patch
@@ -20,7 +20,7 @@ index 6cba89b..33baba1 100755
 -	make -C out
 -	cp ./out/Debug/libuv.a $DEPS_DIR/build/lib
 +    sh autogen.sh
-+    ./configure --host=aarch64-lmp-linux-gnu
++    ./configure --host=$TARGET_SYS
 +    make -B
 +    cp ./.libs/libuv.a $DEPS_DIR/build/lib
  fi

--- a/recipes-wigwag/maestro/maestro_0.0.1.inc
+++ b/recipes-wigwag/maestro/maestro_0.0.1.inc
@@ -77,7 +77,7 @@ do_configure_append() {
       CONFIG_OPTIONS="--host=ia32 ${ARCHFLAGS}"
     fi
     export CONFIG_OPTIONS="${CONFIG_OPTIONS}"
-    ./install-deps.sh
+    TARGET_SYS=${TARGET_SYS} ./install-deps.sh
   cd $entry_dir
 
   # build greaseGo


### PR DESCRIPTION
Not all the build devices are necessarily aarch64-linux devices, this PR fixes possible issues arising from the assumptions of the patch

TARGET_SYS documented here:
https://www.yoctoproject.org/docs/2.0.2/ref-manual/ref-manual.html#var-TARGET_SYS