### PR TITLE
Updated identity,kubelet & info source file protocol from ssh to https

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -98,6 +98,4 @@ RM_OLD_IMAGE = "1"
 INHERIT += "rm_work"
 CONF_VERSION = "1"
 
-export SSH_AUTH_SOCK
-
 DISABLE_VC4GRAPHICS = "1"

--- a/recipes-connectivity/identity-tool/identity-tool_0.0.1.bb
+++ b/recipes-connectivity/identity-tool/identity-tool_0.0.1.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/pe-utils/LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI="\
-git://git@github.com/armPelionEdge/pe-utils.git;protocol=ssh;name=pe-utils;destsuffix=git/pe-utils \
+git://git@github.com/armPelionEdge/pe-utils.git;protocol=https;name=pe-utils;destsuffix=git/pe-utils \
 file://wait-for-pelion-identity.service \
 "
 

--- a/recipes-containers/kubelet/kubelet_git.bb
+++ b/recipes-containers/kubelet/kubelet_git.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 inherit go pkgconfig gitpkgv systemd
-SRC_URI = "git://git@github.com/armPelionEdge/edge-kubelet.git;protocol=ssh;branch=master;depth=1 \
+SRC_URI = "git://git@github.com/armPelionEdge/edge-kubelet.git;protocol=https;branch=master;depth=1 \
 file://10-c2d.conf \
 file://99-loopback.conf \
 file://kubeconfig \

--- a/recipes-misc/info-tool/info-tool_2.0.0.bb
+++ b/recipes-misc/info-tool/info-tool_2.0.0.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/pe-utils/LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI="\
-git://git@github.com/armPelionEdge/pe-utils.git;protocol=ssh;name=pe-utils;destsuffix=git/pe-utils \
+git://git@github.com/armPelionEdge/pe-utils.git;protocol=https;name=pe-utils;destsuffix=git/pe-utils \
 "
 
 #SRCREV_FORMAT = "wwrelay-dss"


### PR DESCRIPTION
Some customers has reported that they are unable to build meta-pelion-edge
as their corporate firewall only allows outbound HTTP/HTTPS but not SSH. This
should help with that use case.