### PR TITLE
Add a support patch to read MAC from EEPROM on Xilinx/AVNET ZU3EG board

### DIFF
--- a/meta-lmp-support/recipes-bsp/u-boot/u-boot-fio/uz/0001-Read-MAC-from-EEPROM-on-Xilinx.patch
+++ b/meta-lmp-support/recipes-bsp/u-boot/u-boot-fio/uz/0001-Read-MAC-from-EEPROM-on-Xilinx.patch
@@ -1,0 +1,42 @@
+From 639eb84dad63d917b325b25fabefebb4f610e3ec Mon Sep 17 00:00:00 2001
+From: Ari Parkkila <ari.parkkila@pelion.com>
+Date: Wed, 24 Feb 2021 15:50:45 +0200
+Subject: [PATCH] Read MAC from EEPROM on Xilinx
+
+
+diff --git a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
+index 99eced2..353a111 100644
+--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
++++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
+@@ -30,6 +30,11 @@
+ 			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
++
++        chosen {
++                xlnx,eeprom = &eeprom; /* EMAC on EEPROM */
++        };
++
+ };
+ 
+ /* Ethernet0 with hard-coded MAC */
+@@ -37,7 +42,6 @@
+ 	status = "okay";
+ 	phy-handle = <&phy0>;
+ 	phy-mode = "rgmii-id";
+-	local-mac-address = [00 0a 35 00 02 90];
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_gem3_default>;
+ 	phy0: ethernet-phy@9 {
+@@ -69,7 +73,7 @@
+ 			#size-cells = <0>;
+ 			reg = <0>;
+ 			/* IIC_EEPROM */
+-			eeprom@51 { /* U5 on UZ3EG IOCC and U7 on the UZ7EV EVCC*/
++			eeprom: eeprom@51 { /* U5 on UZ3EG IOCC and U7 on the UZ7EV EVCC*/
+ 				compatible = "atmel,24c08";
+ 				reg = <0x51>;
+ 				#address-cells = <0x01>;
+-- 
+2.17.1
+


### PR DESCRIPTION
Add a support patch to read MAC from EEPROM on the Xilinx/AVNET ZU3EG board.

The patch is not applied by default, and it should be used only when EEPROM has been written with a valid MAC address.

To apply patch at LmP root folder: `git -C layers/meta-lmp am ../meta-pelion-edge/meta-lmp-support/recipes-bsp/u-boot/u-boot-fio/uz/0001-Read-MAC-from-EEPROM-on-Xilinx.patch`