### PR TITLE
Read EMAC from EEPROM on uz3eg-iocc

### DIFF
--- a/meta-lmp-support/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-lmp-support/recipes-bsp/device-tree/device-tree.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend_uz := "${THISDIR}/files:"
+
+SRC_URI_append_uz = " \
+        file://Read-EMAC-from-EEPROM-on-uz3eg-iocc.patch;patchdir=..;striplevel=8 \
+"
+
+COMPATIBLE_MACHINE_uz = ".*"

--- a/meta-lmp-support/recipes-bsp/device-tree/files/uz3eg-iocc/Read-EMAC-from-EEPROM-on-uz3eg-iocc.patch
+++ b/meta-lmp-support/recipes-bsp/device-tree/files/uz3eg-iocc/Read-EMAC-from-EEPROM-on-uz3eg-iocc.patch
@@ -1,11 +1,11 @@
-From 639eb84dad63d917b325b25fabefebb4f610e3ec Mon Sep 17 00:00:00 2001
+From 536709ded5ff28f82c42bdc04a1378255a3a0371 Mon Sep 17 00:00:00 2001
 From: Ari Parkkila <ari.parkkila@pelion.com>
-Date: Wed, 24 Feb 2021 15:50:45 +0200
-Subject: [PATCH] Read MAC from EEPROM on Xilinx
+Date: Tue, 30 Mar 2021 11:10:45 +0300
+Subject: [PATCH] Read EMAC from EEPROM on uz3eg-iocc
 
 
 diff --git a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
-index 99eced2..353a111 100644
+index 1750937..7b01a4b 100644
 --- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
 +++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
 @@ -30,6 +30,11 @@


### PR DESCRIPTION
Remove fixed EMAC address from device-tree and read it from EEPROM.

Tested on an AES-ZU3EG-1-SK-G evaluation board.

Without this change:
```
Warning: ethernet@ff0e0000 using MAC address from DT
ZynqMP> printenv ethaddr
ethaddr=00:0a:35:00:02:90
```
With this change and EEPROM UNinitialized:
```
Warning: ethernet@ff0e0000 (eth0) using random MAC address - c2:d0:ec:05:1d:af
```
Write MAC on EEPROM:
```
Hit any key to stop autoboot:  0
ZynqMP> i2c dev 2
Setting bus to 2
ZynqMP> mm.b 0
00000000: 60 ? 12
00000001: 09 ? 34
00000002: 00 ? 56
00000003: 20 ? 78
00000004: 00 ? 9a
00000005: 00 ? bc
00000006: 00 ? q
ZynqMP> i2c write 0 51 20 6
ZynqMP> reset
...
Warning: ethernet@ff0e0000 using MAC address from ROM
```