### PR TITLE
 sdimage-zu3 - fix comment on target

### DIFF
--- a/meta-lmp-support/wic/sdimage-uz-sota-config.wks.in
+++ b/meta-lmp-support/wic/sdimage-uz-sota-config.wks.in
@@ -1,4 +1,4 @@
-# Image partition layout for IMX8 Mini EVK supporting Pelion Edge update
+# Image partition layout for AVNET ZU3EG supporting Pelion Edge update
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 20
 part / --source otaimage --ondisk mmcblk --fstype=ext4 --align 4096 --size 8000M
 part /mnt/config --size 10M --ondisk mmcblk --fstype=ext4 --label config --align 4096


### PR DESCRIPTION
Comment referes to i.MX8, but really this file is for the AVNET ZU3EG.