### PR TITLE
Use LABELs in fstab

### DIFF
--- a/meta-lmp-support/recipes-core/base-files/base-files/imx8mmevk/fstab
+++ b/meta-lmp-support/recipes-core/base-files/base-files/imx8mmevk/fstab
@@ -4,10 +4,10 @@ devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
-# boot partition
-/dev/mmcblk1p1       /mnt/boot            vfat       noatime,sync          0  0
-/dev/mmcblk1p3       /mnt/config          auto       defaults              0  0
-/dev/mmcblk1p5       /mnt/flags           auto       defaults              0  0
-/dev/mmcblk1p6       /mnt/cache           auto       defaults              0  0
-/dev/mmcblk1p7       /userdata            auto       defaults              0  0
+# Use LABELs to locate partitions
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=config         /mnt/config          auto       defaults              0  0
+LABEL=flags          /mnt/flags           auto       defaults              0  0
+LABEL=cache          /mnt/cache           auto       defaults              0  0
+LABEL=userdata       /userdata            auto       defaults              0  0
 

--- a/meta-lmp-support/recipes-core/base-files/base-files/uz/fstab
+++ b/meta-lmp-support/recipes-core/base-files/base-files/uz/fstab
@@ -4,9 +4,9 @@ devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
-# boot partition
+# Use LABELs to locate partitions
 LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
-/dev/mmcblk1p3       /mnt/config          auto       defaults              0  0
-/dev/mmcblk1p5       /mnt/flags           auto       defaults              0  0
-/dev/mmcblk1p6       /mnt/cache           auto       defaults              0  0
-/dev/mmcblk1p7       /userdata            auto       defaults              0  0
+LABEL=config         /mnt/config          auto       defaults              0  0
+LABEL=flags          /mnt/flags           auto       defaults              0  0
+LABEL=cache          /mnt/cache           auto       defaults              0  0
+LABEL=userdata       /userdata            auto       defaults              0  0


### PR DESCRIPTION
Use LABELs instead of mmcblocks - they are  pain the back to maintain/figure out. LABELs are portable, more abstract and are more likely to remain the same even if the partitioning changes a bit. The `fstab` file is likely going to be 100% same for all the targets this way.
