### PR TITLE
LmP RaspberryPi3/4 support

### DIFF
--- a/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
+++ b/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
@@ -1,4 +1,5 @@
 WKS_FILE_sota_mx8mm = "sdimage-imx8-spl-sota-config.wks.in"
+WKS_FILE_sota_rpi = "sdimage-rpi3-spl-sota-config.wks.in"
 
 #Use ttyAMA0 instead of ttyS0 that is set in meta-lmp
 KERNEL_SERIAL_rpi = "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyAMA0,115200", "", d)}"

--- a/meta-lmp-support/recipes-core/base-files/base-files/rpi/fstab
+++ b/meta-lmp-support/recipes-core/base-files/base-files/rpi/fstab
@@ -1,0 +1,14 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# boot partition
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=config         /mnt/config          auto       defaults              0  0
+LABEL=flags          /mnt/flags           auto       defaults              0  0
+LABEL=cache          /mnt/cache           auto       defaults              0  0
+LABEL=userdata       /userdata            auto       defaults              0  0
+
+

--- a/meta-lmp-support/wic/sdimage-rpi3-spl-sota-config.wks.in
+++ b/meta-lmp-support/wic/sdimage-rpi3-spl-sota-config.wks.in
@@ -1,0 +1,8 @@
+# Image partition layout for Raspberry PI3B+ supporting Pelion Edge update
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --fixed-size 128
+part / --source otaimage --ondisk mmcblk --fstype=ext4 --align 4096 --size 8000M
+part /mnt/config --size 10M --ondisk mmcblk --fstype=ext4 --label config --align 4096
+part /mnt/flags --size 10M --ondisk mmcblk --fstype=ext4 --label flags --align 4096
+part /mnt/cache --size 10M --ondisk mmcblk --fstype=ext4 --label cache --align 4096
+part /userdata --size 1024 --ondisk mmcblk --fstype=ext4 --label userdata
+

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -1,5 +1,5 @@
 
-COMPATIBLE_MACHINE = "raspberrypi3"
+COMPATIBLE_MACHINE = "^rpi$"
 
 do_deploy_append() {
     if [ -z "${MENDER_ARTIFACT_NAME}" ]; then

--- a/recipes-wigwag/maestro/maestro-rpi3.bb
+++ b/recipes-wigwag/maestro/maestro-rpi3.bb
@@ -1,6 +1,6 @@
 require maestro_0.0.1.inc
 
-COMPATIBLE_MACHINE = "raspberrypi3"
+COMPATIBLE_MACHINE = "^rpi$"
 
 PROVIDES += " maestro "
 RPROVIDES_${PN} += " maestro "


### PR DESCRIPTION
Raspberry Pi3/4 support. Thanks to Kimmo for finding that one missing piece and verifying the RPI4B.
This change more or less generalizes the current RPI3 support for all Raspberries, as the changes are not actually board specific.

Full functionality requires also changes in meta-mbed-edge, see PR https://github.com/PelionIoT/meta-mbed-edge/pull/47.
