### PR TITLE
Replace nmtui with nmcli

### DIFF
--- a/meta-lmp-support/recipes-core/images/console-image-lmp.bb
+++ b/meta-lmp-support/recipes-core/images/console-image-lmp.bb
@@ -16,7 +16,7 @@ DEPENDS += "deviceos-users"
 
 CORE_IMAGE_BASE_INSTALL += " \
     kernel-modules \
-    networkmanager-nmtui \
+    networkmanager-nmcli \
     git \
     vim \
     rng-tools \


### PR DESCRIPTION
Testing team needs `nmcli` so replacing `nmtui` with it.