### PR TITLE
use miniuart bt dtoverlay to enable bluetooth again

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -20,7 +20,9 @@ do_deploy_append() {
 
     if [ -n "${ENABLE_SERIAL_CONSOLE}" ]; then
         echo "" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
-        echo "dtoverlay=disable-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "#meta-pelion-edge changes default tty to one used by bt by default, either disable ble or use to miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "#dtoverlay=disable-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # match the u-boot.bin install name set in IMAGE_BOOT_FILES by meta-raspberrypi/conf/machine/include/rpi-base.inc


### PR DESCRIPTION
starts using miniuart-bt as default overlay as we are reserving main uart for serial command line.