### PR TITLE
Use standard tty config, fixes ble

### DIFF
--- a/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
+++ b/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
@@ -1,6 +1,7 @@
 
 #Use ttyAMA0 instead of ttyS0 that is set in meta-lmp
-KERNEL_SERIAL_rpi = "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyAMA0,115200", "", d)}"
+#this can cause problems with bluetooth. config removed
+#KERNEL_SERIAL_rpi = "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyAMA0,115200", "", d)}"
 
 #Docker requires cgroup memory
 OSTREE_KERNEL_ARGS_COMMON += "cgroup_enable=memory cgroup_memory=1"

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -22,7 +22,7 @@ do_deploy_append() {
         echo "" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
         echo "#meta-pelion-edge changes default tty to one used by bt by default, either disable ble or use to miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
         echo "#dtoverlay=disable-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
-        echo "dtoverlay=miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "#dtoverlay=miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # match the u-boot.bin install name set in IMAGE_BOOT_FILES by meta-raspberrypi/conf/machine/include/rpi-base.inc

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -20,7 +20,9 @@ do_deploy_append() {
 
     if [ -n "${ENABLE_SERIAL_CONSOLE}" ]; then
         echo "" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
-        echo "dtoverlay=disable-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "#meta-pelion-edge changes default tty to one used by bt by default, either disable ble or use to miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "#dtoverlay=disable-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # match the u-boot.bin install name set in IMAGE_BOOT_FILES by meta-raspberrypi/conf/machine/include/rpi-base.inc


### PR DESCRIPTION
another way to fix ble for raspberry is just to use default console settings instead of hardcoding console=ttyAMA0 for serial console.