### PR TITLE
Raspberry issue testing ci

### DIFF
--- a/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
+++ b/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
@@ -1,7 +1,7 @@
 
 #Use ttyAMA0 instead of ttyS0 that is set in meta-lmp
 #this can cause problems with bluetooth. config removed
-#KERNEL_SERIAL_rpi = "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyAMA0,115200", "", d)}"
+KERNEL_SERIAL_rpi = "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyAMA0,115200", "", d)}"
 
 #Docker requires cgroup memory
 OSTREE_KERNEL_ARGS_COMMON += "cgroup_enable=memory cgroup_memory=1"

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -22,7 +22,7 @@ do_deploy_append() {
         echo "" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
         echo "#meta-pelion-edge changes default tty to one used by bt by default, either disable ble or use to miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
         echo "#dtoverlay=disable-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
-        echo "#dtoverlay=miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=miniuart-bt" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # match the u-boot.bin install name set in IMAGE_BOOT_FILES by meta-raspberrypi/conf/machine/include/rpi-base.inc


### PR DESCRIPTION
test7 for rasp was failing and seemed to pass with these changes in https://github.com/PelionIoT/manifest-lmp-pelion-edge/pull/35 which pointed to this PR's hash in git.