### PR TITLE
Add local host and forward address for container domain

### DIFF
--- a/recipes-core/netbase/netbase/hosts
+++ b/recipes-core/netbase/netbase/hosts
@@ -1,5 +1,6 @@
 127.0.0.1       localhost.localdomain           localhost
-127.0.0.1		gateways.local
+127.0.0.1       gateways.local
+127.0.0.1       containers.local
 
 # The following lines are desirable for IPv6 capable hosts
 ::1     localhost ip6-localhost ip6-loopback

--- a/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
+++ b/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
@@ -21,6 +21,7 @@ EDGE_PROXY_DEBUG=false
 
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress /userdata/edge_gw_config/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress /userdata/edge_gw_config/identity.json)
+CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress /userdata/edge_gw_config/identity.json)
 DEVICE_ID=$(jq -r .deviceID /userdata/edge_gw_config/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /wigwag/etc/edge-proxy.conf.json)
 
@@ -48,4 +49,4 @@ exec /wigwag/system/bin/edge-proxy \
 -cert-strategy-options=path=/1/pt \
 -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
 -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
--forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}
+-forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\",\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}


### PR DESCRIPTION
1. Modify edge-proxy config to add new forwarding address for containers domain
2. Add `containers.local` to the list of known hosts