### PR TITLE
Add local host and forward address for container domain

### DIFF
--- a/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
+++ b/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
@@ -21,6 +21,7 @@ EDGE_PROXY_DEBUG=false
 
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress /userdata/edge_gw_config/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress /userdata/edge_gw_config/identity.json)
+CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress /userdata/edge_gw_config/identity.json)
 DEVICE_ID=$(jq -r .deviceID /userdata/edge_gw_config/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /wigwag/etc/edge-proxy.conf.json)
 
@@ -48,4 +49,4 @@ exec /wigwag/system/bin/edge-proxy \
 -cert-strategy-options=path=/1/pt \
 -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
 -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
--forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}
+-forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\",\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}

--- a/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
+++ b/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
@@ -25,6 +25,10 @@ CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress /userdata/edge_gw_config/id
 DEVICE_ID=$(jq -r .deviceID /userdata/edge_gw_config/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /wigwag/etc/edge-proxy.conf.json)
 
+      if ! grep -q "containers.local" /etc/hosts; then
+          echo "127.0.0.1 containers.local" >> /etc/hosts
+      fi
+
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
 fi

--- a/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
+++ b/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
@@ -25,9 +25,9 @@ CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress /userdata/edge_gw_config/id
 DEVICE_ID=$(jq -r .deviceID /userdata/edge_gw_config/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /wigwag/etc/edge-proxy.conf.json)
 
-      if ! grep -q "containers.local" /etc/hosts; then
-          echo "127.0.0.1 containers.local" >> /etc/hosts
-      fi
+if ! grep -q "containers.local" /etc/hosts; then
+    echo "127.0.0.1 containers.local" >> /etc/hosts
+fi
 
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts

--- a/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
+++ b/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
@@ -53,4 +53,4 @@ exec /wigwag/system/bin/edge-proxy \
 -cert-strategy-options=path=/1/pt \
 -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
 -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
--forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\",\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}
+-forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"\,\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}


### PR DESCRIPTION
Mirroring #301. @OPpuolitaival this is to investigate why PR checks are not catching the problem. Once we have that I can update this PR with the fix. 

1. Modify edge-proxy config to add new forwarding address for containers domain
1. Add `containers.local` to the list of known hosts