### PR TITLE
Upgraded identity and info tool to 2.0.7

### DIFF
--- a/recipes-connectivity/identity-tool/identity-tool_0.0.1.bb
+++ b/recipes-connectivity/identity-tool/identity-tool_0.0.1.bb
@@ -9,7 +9,7 @@ file://wait-for-pelion-identity.service \
 "
 
 #SRCREV_FORMAT = "wwrelay-dss"
-SRCREV_pe-utils = "2.0.6"
+SRCREV_pe-utils = "2.0.7"
 
 inherit pkgconfig gitpkgv systemd
 

--- a/recipes-misc/info-tool/info-tool_2.0.0.bb
+++ b/recipes-misc/info-tool/info-tool_2.0.0.bb
@@ -8,7 +8,7 @@ git://git@github.com/armPelionEdge/pe-utils.git;protocol=https;name=pe-utils;des
 "
 
 #SRCREV_FORMAT = "wwrelay-dss"
-SRCREV_pe-utils = "2.0.6"
+SRCREV_pe-utils = "2.0.7"
 
 inherit pkgconfig gitpkgv 
 


### PR DESCRIPTION
This should fix the derivation of edge gw addresses from lwm2m addr. 