### PR TITLE
Avoid conflict in other layers with firmware recipes

### DIFF
--- a/meta-imx8mmsolidrun-support/recipes-kernel/linux-firmware/linux-firmware-cyw-bt-patch-bcm43455_git.bb
+++ b/meta-imx8mmsolidrun-support/recipes-kernel/linux-firmware/linux-firmware-cyw-bt-patch-bcm43455_git.bb
@@ -13,7 +13,7 @@ PV = "20201214"
 
 S = "${WORKDIR}/git"
 
-# CYPRESS_CONFLICT_PACKAGE ?= "bcm43455"
+CYPRESS_CONFLICT_PACKAGE ?= "bcm43455"
 CYPRESS_PART_BT ?= "4345C0"
 CYPRESS_MODEL ?= "1MW"
 
@@ -39,11 +39,13 @@ FILES_${PN} = " \
     ${sysconfdir}/firmware \
 "
 
-# RCONFLICTS_${PN} = "\
-#     linux-firmware-${CYPRESS_CONFLICT_PACKAGE} \
-#     linux-firmware-raspbian-${CYPRESS_CONFLICT_PACKAGE} \
-# "
-# RREPLACES_${PN} = "\
-#     linux-firmware-${CYPRESS_CONFLICT_PACKAGE} \
-#     linux-firmware-raspbian-${CYPRESS_CONFLICT_PACKAGE} \
-# "
+RCONFLICTS_${PN} = "\
+    linux-firmware-${CYPRESS_CONFLICT_PACKAGE} \
+    linux-firmware-raspbian-${CYPRESS_CONFLICT_PACKAGE} \
+"
+RREPLACES_${PN} = "\
+    linux-firmware-${CYPRESS_CONFLICT_PACKAGE} \
+    linux-firmware-raspbian-${CYPRESS_CONFLICT_PACKAGE} \
+"
+
+COMPATIBLE_MACHINE_imx8mmsolidrun = ".*"

--- a/meta-imx8mmsolidrun-support/recipes-kernel/linux-firmware/linux-firmware-cyw-fmac-fw-bcm43455-sdio_git.bb
+++ b/meta-imx8mmsolidrun-support/recipes-kernel/linux-firmware/linux-firmware-cyw-fmac-fw-bcm43455-sdio_git.bb
@@ -30,3 +30,5 @@ FILES_${PN} = " \
     ${nonarch_base_libdir}/firmware/brcm/brcmfmac${CYPRESS_PART}.bin \
     ${nonarch_base_libdir}/firmware/brcm/brcmfmac${CYPRESS_PART}.clm_blob \
 "
+
+COMPATIBLE_MACHINE_imx8mmsolidrun = ".*"

--- a/meta-imx8mmsolidrun-support/recipes-kernel/linux-firmware/linux-firmware-cyw-fmac-nvram-bcm43455-sdio_git.bb
+++ b/meta-imx8mmsolidrun-support/recipes-kernel/linux-firmware/linux-firmware-cyw-fmac-nvram-bcm43455-sdio_git.bb
@@ -28,3 +28,5 @@ FILES_${PN} = " \
     ${nonarch_base_libdir}/firmware/LICENCE.cyw-fmac-nvram \
     ${nonarch_base_libdir}/firmware/brcm/brcmfmac${CYPRESS_PART}.txt \
 "
+
+COMPATIBLE_MACHINE_imx8mmsolidrun = ".*"

--- a/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
+++ b/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
@@ -24,7 +24,7 @@ IMAGE_BOOT_FILES_append_lmp-base_imx8mmsolidrun = " \
 
 # Add additional firmware for Wifi/BT
 MACHINE_FIRMWARE_append_imx8mmsolidrun = " \
-       linux-firmware-cyw-fmac-fw \
-       linux-firmware-cyw-fmac-nvram \
-       linux-firmware-cyw-bt-patch \
+       linux-firmware-cyw-fmac-fw-bcm43455-sdio \
+       linux-firmware-cyw-fmac-nvram-bcm43455-sdio \
+       linux-firmware-cyw-bt-patch-bcm43455 \
 "


### PR DESCRIPTION
Foundries commits f2fb8571bc4084b15fb6a73edf6965ecc363f405 and 62f03ea2eb9063c94966fcbd3525d75cc2e67990