### PR TITLE
sets ostree's branch to main as master removed and broke the build.

### DIFF
--- a/recipes-extended/ostree/ostree/update-default-grub-cfg-header.patch
+++ b/recipes-extended/ostree/ostree/update-default-grub-cfg-header.patch
@@ -1,0 +1,15 @@
+diff --git a/src/boot/grub2/ostree-grub-generator b/src/boot/grub2/ostree-grub-generator
+index 97ef4d69..b418c2fb 100644
+--- a/src/boot/grub2/ostree-grub-generator
++++ b/src/boot/grub2/ostree-grub-generator
+@@ -91,8 +91,8 @@ populate_header()
+ {
+ cat >> ${new_grub2_cfg} <<EOF
+ serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+-default=boot
+-timeout=10
++default=0
++timeout=1
+ 
+ EOF
+ }

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# Disable PTEST for ostree as it requires options that are not enabled when
+# building with meta-updater and meta-lmp.
+
+PTEST_ENABLED = "0"
+
+SRC_URI = " \
+    gitsm://github.com/ostreedev/ostree;branch=main \
+    file://update-default-grub-cfg-header.patch \
+"
+
+# gpgme is not required by us, and it brings GPLv3 dependencies
+PACKAGECONFIG_remove = "gpgme"


### PR DESCRIPTION
Copies foundries.io ostree modifications to ensure changes are compiled into the build.