### PR TITLE
Fix the build when MBED_EDGE_CORE_CONFIG_PARSEC_TPM_SE_SUPPORT = ON.

### DIFF
--- a/recipes-wigwag/mbed-fcce/mbed-fcce/0001-fix-arm_uc_pal_linux_extensions.manual_patch
+++ b/recipes-wigwag/mbed-fcce/mbed-fcce/0001-fix-arm_uc_pal_linux_extensions.manual_patch
@@ -1,0 +1,13 @@
+diff --git a/update-client-hub/modules/pal-filesystem/source/arm_uc_pal_linux_extensions.c b/update-client-hub/modules/pal-filesystem/source/arm_uc_pal_linux_extensions.c
+index 3308512..41bd370 100644
+--- a/update-client-hub/modules/pal-filesystem/source/arm_uc_pal_linux_extensions.c
++++ b/update-client-hub/modules/pal-filesystem/source/arm_uc_pal_linux_extensions.c
+@@ -32,6 +32,8 @@
+ #include <stdlib.h>
+ #include <inttypes.h>
++#include <bits/local_lim.h>
++#include <pthread.h>
+ #include <limits.h>
+ #include <stdio.h>
+ #include <unistd.h>
+

--- a/recipes-wigwag/mbed-fcce/mbed-fcce/0001-fix-mcc_common_setup.manual_patch
+++ b/recipes-wigwag/mbed-fcce/mbed-fcce/0001-fix-mcc_common_setup.manual_patch
@@ -1,0 +1,17 @@
+diff --git a/source/platform/Linux/mcc_common_setup.c b/source/platform/Linux/mcc_common_setup.c
+index 7078ab2..f220b9d 100644
+--- a/source/platform/Linux/mcc_common_setup.c
++++ b/source/platform/Linux/mcc_common_setup.c
+@@ -22,9 +22,11 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <asm-generic/signal.h>
+ #include <signal.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <linux/time.h>
+ #include <time.h>
+ #include "mcc_common_setup.h"
+ #include "mcc_common_config.h"
+

--- a/recipes-wigwag/mbed-fcce/mbed-fcce_4.9.0.bb
+++ b/recipes-wigwag/mbed-fcce/mbed-fcce_4.9.0.bb
@@ -18,6 +18,8 @@ git://github.com/parallaxsecond/parsec-se-driver.git;protocol=https;name=parsec;
 git://git@github.com/ARMmbed/factory-configurator-client-example.git;protocol=https; \
 file://0001-Added-trusted-storage-to-Yocto-target.patch \
 file://0001-fix-build-getting-cross-compiler-iface-setting-to-et.patch \
+file://0001-fix-arm_uc_pal_linux_extensions.manual_patch \
+file://0001-fix-mcc_common_setup.manual_patch \
 file://linux-se-config.cmake \
 file://0001-fix_psa_storage_location.patch \
 "
@@ -58,6 +60,9 @@ do_compile() {
 
     if [ "${MBED_EDGE_CORE_CONFIG_PARSEC_TPM_SE_SUPPORT}" = "ON" ]; then
 
+
+        git -C mbed-cloud-client apply ${WORKDIR}/0001-fix-arm_uc_pal_linux_extensions.manual_patch
+        git apply ${WORKDIR}/0001-fix-mcc_common_setup.manual_patch
 
         # Manually adding the parsec-se-driver Middleware
         cp -R ${WORKDIR}/parsec-se-driver ${S}/pal-platform/Middleware/parsec_se_driver/parsec_se_driver


### PR DESCRIPTION
Reintroduced patches for building with PARSEC_TPM_SE_SUPPORT.