### PR TITLE
Add pkcs11 provider.

### DIFF
--- a/meta-lmp-support/recipes-core/images/console-image-lmp.bb
+++ b/meta-lmp-support/recipes-core/images/console-image-lmp.bb
@@ -67,17 +67,18 @@ git \
 panic \
 "
 
-PARSEC_SERVICE = " \
+PARSEC_SERVICE_SOFTWARE_TPM = " \
 parsec-service-tpm \
+swtpm-service \
+tpm2-tools \
+"
+
+PARSEC_SERVICE_PKCS11 = " \
+parsec-service-pkcs11 \
 "
 
 PARSEC_TOOL = " \
 parsec-tool \
-"
-
-SOFTWARE_TPM = " \
-swtpm-service \
-tpm2-tools \
 "
 
 IMAGE_INSTALL += " \
@@ -89,10 +90,10 @@ ${PELION_SYSTEMS_MANAGEMENT} \
 ${PELION_CONTAINER_ORCHESTRATION} \
 ${PELION_TESTING} \
 ${MACHINE_EXTRA_RRECOMMENDS} \
-${PARSEC_SERVICE} \
 ${PARSEC_TOOL} \
-${SOFTWARE_TPM} \
 "
+IMAGE_INSTALL_append = " ${@bb.utils.contains('PARSEC_PROVIDER', 'PKCS11', '${PARSEC_SERVICE_PKCS11}', '',d)}"
+IMAGE_INSTALL_append = " ${@bb.utils.contains('PARSEC_PROVIDER', 'SOFTWARE_TPM', '${PARSEC_SERVICE_SOFTWARE_TPM}', '',d)}"
 
 USERADD_UID_TABLES += "files/pelion-passwd-table"
 USERADD_GID_TABLES += "files/pelion-group-table"
@@ -113,7 +114,9 @@ ROOTFS_POSTPROCESS_COMMAND_append = " \
 setup_parsec_files() {
     chown -R parsec:parsec ${IMAGE_ROOTFS}/etc/parsec
     chown -R parsec:parsec ${IMAGE_ROOTFS}/usr/libexec/parsec
-    chown parsec:parsec ${IMAGE_ROOTFS}/usr/bin/swtpm.sh
+    if [ "${PARSEC_PROVIDER}" = "SOFTWARE_TPM" ]; then
+        chown parsec:parsec ${IMAGE_ROOTFS}/usr/bin/swtpm.sh
+    fi
 }
 set_local_timezone() {
     ln -sf /usr/share/zoneinfo/EST5EDT ${IMAGE_ROOTFS}/etc/localtime


### PR DESCRIPTION
Added the PKCS11 provider as an alternative to the SW TPM provider.

The provider to be used is controlled using the PARSEC_PROVIDER variable in local.conf

This can either be SOFTWARE_TPM or PKCS11.

The relevant files will then be selected based upon that.