### PR TITLE
Enforce deploy before install on uz machines

### DIFF
--- a/meta-lmp-support/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
+++ b/meta-lmp-support/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
@@ -1,0 +1,5 @@
+COMPATIBLE_MACHINE = "uz"
+
+# do_deploy is skipped if valid in the shared state cache and copied to DEPLOY_DIR_IMAGE,
+# which is missed in install of openembedded-core/u-boot.inc
+addtask deploy before do_install


### PR DESCRIPTION
Fix for CI on Xilinx machines to enforce deploy before install, see note of do_deploy at https://docs.yoctoproject.org/current/overview-manual/concepts.html#shared-state