### PR TITLE
First pass at OSTree diff/fsck

### DIFF
--- a/meta-lmp-support/recipes-core/images/initramfs-ostree-lmp-image.bbappend
+++ b/meta-lmp-support/recipes-core/images/initramfs-ostree-lmp-image.bbappend
@@ -1,0 +1,1 @@
+PACKAGE_INSTALL_append = " initramfs-module-ostreecheck"

--- a/meta-lmp-support/recipes-core/initrdscripts/initramfs-framework/ostreecheck
+++ b/meta-lmp-support/recipes-core/initrdscripts/initramfs-framework/ostreecheck
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Initial concept of how to do OSTree fsck+diff to check
+# rootfs integrity.
+#
+# TODO:
+# - uncomment "fatal"s
+# - change various "msg" to "info"/"debug"
+# - verify validity of deployment hash via a signature
+# - verify version number to prevent rollback
+# - handling of /etc ?
+
+ostreecheck_enabled() {
+	return 0
+}
+
+ostreecheck_run() {
+	msg "OSTree check here"
+	ls -l /
+	ls -l /sysroot
+	/usr/bin/ostree fsck --repo=$ROOTFS_DIR/ostree/repo
+	if [ $? -ne 0 ]; then
+		msg "OSTree repo is damaged!"
+		#fatal
+	else
+		msg "OSTree repo intact"
+	fi
+
+	OSTREE_DEPLOY=`/usr/bin/ostree admin --sysroot=$ROOTFS_DIR --print-current-dir`
+	if [ $? -ne 0 ]; then
+		msg "OSTree admin --print-current-dir failed"
+		return
+		#fatal
+	fi
+
+	msg "OSTree deployment is at ${OSTREE_DEPLOY}"
+
+	# Extract revision ID from deployment path by
+	# stripping everything up to the last '/',
+	# and everything after the last '.'
+	ostree_rev="${OSTREE_DEPLOY##*/}"
+	ostree_rev="${ostree_rev%%.*}"
+	if [ -z "${ostree_rev}" ]; then
+		msg "No OSTree rev found"
+		return 1
+		#fatal
+	fi
+
+	msg "Checking contents of OSTree rev ${ostree_rev}"
+	# For now just look for modified or deleted usr files
+	# (We would expect to see a bunch of added etc and var files.)
+	# grep returns 0 if any matches are found
+	/usr/bin/ostree diff --repo=$ROOTFS_DIR/ostree/repo ${ostree_rev} ${OSTREE_DEPLOY} | grep "[MD] *usr/"
+	if [ $? -eq 0 ]; then
+		msg "OSTree deployment modified"
+		#fatal
+	else
+		msg "OSTree deployment intact"
+	fi
+}

--- a/meta-lmp-support/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-lmp-support/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+	file://ostreecheck \
+"
+
+PACKAGES_append = " initramfs-module-ostreecheck"
+
+SUMMARY_initramfs-module-ostreecheck = "initramfs support for ostree based filesystems"
+RDEPENDS_initramfs-module-ostreecheck = "${PN}-base ostree"
+FILES_initramfs-module-ostreecheck = "/init.d/985-ostreecheck"
+
+do_install_append() {
+	install -m 0755 ${WORKDIR}/ostreecheck ${D}/init.d/985-ostreecheck
+}


### PR DESCRIPTION
Addition of OSTree fsck+diff to initramfs for LMP builds.

Currently unconditional - this adds complete ostree to initramfs, potentially increasing its size by 10MB.

Check pass/failure are only logged. The "fatal" directives that would enforce it are commented out.