### PR TITLE
Override optee recipe for PKCS11 support.

### DIFF
--- a/meta-lmp-support/recipes-security/optee/optee-os-fio_3.10.0.bbappend
+++ b/meta-lmp-support/recipes-security/optee/optee-os-fio_3.10.0.bbappend
@@ -1,0 +1,16 @@
+SUMMARY = "OP-TEE Trusted OS"
+DESCRIPTION = "Open Portable Trusted Execution Environment - Trusted side of the TEE"
+HOMEPAGE = "https://www.op-tee.org/"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+
+# Disable trace messages
+EXTRA_OEMAKE_remove = "CFG_TEE_CORE_LOG_LEVEL=2"
+EXTRA_OEMAKE_remove = "CFG_TEE_TA_LOG_LEVEL=2"
+
+# Disable use of crypto driver - it is not compatible with PARSEC/PKCS11
+EXTRA_OEMAKE_remove_mx8 = "CFG_CRYPTO_DRIVER=y"
+EXTRA_OEMAKE_append_mx8 = "CFG_CRYPTO_DRIVER=n"
+
+


### PR DESCRIPTION
Disable trace messages from the trusted application.

On the imx boards choose not to use the CRYPTO_DRIVER as is does not
correctly support variable length buffers used by the PARSEC PKCS11
provider.