### PR TITLE
Set PARSEC_PROVIDER per device type.

### DIFF
--- a/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
+++ b/meta-lmp-support/conf/machine/include/lmp-factory-custom.inc
@@ -8,3 +8,13 @@ OSTREE_KERNEL_ARGS_COMMON += "cgroup_enable=memory cgroup_memory=1"
 
 #Use sdcard as root device by default
 OSTREE_KERNEL_ARGS_imx8mm-lpddr4-evk = "console=tty1 console=ttymxc1,115200 earlycon=ec_imx6q,0x30890000,115200 root=/dev/mmcblk1p2 rootfstype=ext4"
+
+# Set defaults for PARSEC_PROVIDER.
+# All boards can support the SOFTWARE_TPM.
+# The mx8 and uz boards can use PKCS11
+# The rpi can only use the SOFTWARE_TPM
+
+PARSEC_PROVIDER ?= "SOFTWARE_TPM"
+PARSEC_PROVIDER_uz ?= "PKCS11"
+PARSEC_PROVIDER_mx8 ?= "PKCS11"
+PARSEC_PROVIDER_rpi ?= "SOFTWARE_TPM"


### PR DESCRIPTION
Set so all boards use SOFTWARE_TPM by default.

Provide specific overrides for:
 - The mx8 uses PKCS11
 - The uz uses PKCS11
 - The rpi uses SOFTWARE_TPM (not strictly necessary, but is consistent)