### PR TITLE
Patch optee for pkcs11_decrypt.

### DIFF
--- a/meta-lmp-support/recipes-security/optee/files/0001-optee.patch
+++ b/meta-lmp-support/recipes-security/optee/files/0001-optee.patch
@@ -1,0 +1,29 @@
+diff --git a/core/drivers/crypto/crypto_api/acipher/rsa.c b/core/drivers/crypto/crypto_api/acipher/rsa.c
+index 50d53cc9..019ee754 100644
+--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
++++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
+@@ -187,16 +187,21 @@ TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
+ 	struct drvcrypt_rsa *rsa = NULL;
+ 	struct drvcrypt_rsa_ed rsa_data = { };
+ 
+-	if (!key || !msg || !cipher || !msg_len || (!label && label_len)) {
++	if (!key || !cipher || !msg_len || (!label && label_len)) {
+ 		CRYPTO_TRACE("Parameters error (key @%p)\n"
+-			     "(msg @%p size %zu bytes)\n"
++			     "msg size %zu bytes)\n"
+ 			     "(cipher @%p size %zu bytes)\n"
+ 			     "(label @%p size %zu bytes)",
+-			     key, msg, msg_len ? *msg_len : 0,
++			     key, msg_len ? *msg_len : 0,
+ 			     cipher, cipher_len, label, label_len);
+ 		return TEE_ERROR_BAD_PARAMETERS;
+ 	}
+ 
++	if (!msg) {
++		*msg_len = crypto_bignum_num_bytes(key->n);
++		return TEE_ERROR_SHORT_BUFFER;
++	}
++
+ 	rsa = drvcrypt_get_ops(CRYPTO_RSA);
+ 	if (rsa) {
+ 		/* Prepare the encryption data parameters */

--- a/meta-lmp-support/recipes-security/optee/optee-os-fio_3.10.0.bbappend
+++ b/meta-lmp-support/recipes-security/optee/optee-os-fio_3.10.0.bbappend
@@ -4,13 +4,11 @@ HOMEPAGE = "https://www.op-tee.org/"
 
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+FILESEXTRAPATHS_prepend_mx8 := "${THISDIR}/files:"
+SRC_URI_append_mx8 = " file://0001-optee.patch"
+
 
 # Disable trace messages
 EXTRA_OEMAKE_remove = "CFG_TEE_CORE_LOG_LEVEL=2"
 EXTRA_OEMAKE_remove = "CFG_TEE_TA_LOG_LEVEL=2"
-
-# Disable use of crypto driver - it is not compatible with PARSEC/PKCS11
-EXTRA_OEMAKE_remove_mx8 = "CFG_CRYPTO_DRIVER=y"
-EXTRA_OEMAKE_append_mx8 = "CFG_CRYPTO_DRIVER=n"
-
 


### PR DESCRIPTION
The optee_os RSA decrypt code used on imx devices does not correctly
support varialble length buffers. This patch returns the length of
buffer required to support the decrypt when passed a null pointer.