### PR TITLE
Revert "Enable PREEMPT with RCU boost"

### DIFF
--- a/meta-lmp-support/recipes-kernel/linux/files/xilinx_cpu_idle.cfg
+++ b/meta-lmp-support/recipes-kernel/linux/files/xilinx_cpu_idle.cfg
@@ -1,0 +1,5 @@
+# system is not stable enough with cpu idle and preempt enabled
+CONFIG_PREEMPT_NONE=y
+# CONFIG_PREEMPT is not set
+# CONFIG_CPU_IDLE is not set
+

--- a/meta-lmp-support/recipes-kernel/linux/files/xilinx_rcu_boost.cfg
+++ b/meta-lmp-support/recipes-kernel/linux/files/xilinx_rcu_boost.cfg
@@ -1,3 +1,0 @@
-# PREEMPT requires RCU priority boost
-CONFIG_RCU_EXPERT=y
-CONFIG_RCU_BOOST=y

--- a/meta-lmp-support/recipes-kernel/linux/linux-lmp-xlnx_git.bbappend
+++ b/meta-lmp-support/recipes-kernel/linux/linux-lmp-xlnx_git.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
  
-SRC_URI_append_uz = " file://xilinx_rcu_boost.cfg"
+SRC_URI_append_uz = " file://xilinx_cpu_idle.cfg"


### PR DESCRIPTION
This reverts commit 6acc5b204b651482695400a58f7314265e6e7096.

For some reason we have stability issues with the latest dev on AVNET ZU3-EG.
