### PR TITLE
Fix OSTree check

### DIFF
--- a/meta-lmp-support/recipes-core/initrdscripts/initramfs-framework/ostreecheck
+++ b/meta-lmp-support/recipes-core/initrdscripts/initramfs-framework/ostreecheck
@@ -15,9 +15,18 @@ ostreecheck_enabled() {
 }
 
 ostreecheck_run() {
-	msg "OSTree check here"
-	ls -l /
-	ls -l /sysroot
+	# We are running between ostree-prepare-root /rootfs and the move of
+	# that to /.
+
+	# In ostree 2021.1, ostree-prepare-root creates /run/ostree-booted, which
+	# confuses ostree commands run before the remount - they try to remount
+	# /sysroot, which doesn't exist yet.
+	# (Upstream ostree patch to avoid this pending at
+	# https://github.com/ostreedev/ostree/pull/2486 )
+	# Temporarily move the ostree-booted file (if it exists) to make it work.
+	mv /run/ostree-booted /run/ostree-booted.orig 2> /dev/null
+
+	msg "Checking OSTree repo"
 	/usr/bin/ostree fsck --repo=$ROOTFS_DIR/ostree/repo
 	if [ $? -ne 0 ]; then
 		msg "OSTree repo is damaged!"
@@ -28,12 +37,10 @@ ostreecheck_run() {
 
 	OSTREE_DEPLOY=`/usr/bin/ostree admin --sysroot=$ROOTFS_DIR --print-current-dir`
 	if [ $? -ne 0 ]; then
-		msg "OSTree admin --print-current-dir failed"
+		msg "OSTree admin --print-current-dir failed!"
 		return
 		#fatal
 	fi
-
-	msg "OSTree deployment is at ${OSTREE_DEPLOY}"
 
 	# Extract revision ID from deployment path by
 	# stripping everything up to the last '/',
@@ -41,20 +48,23 @@ ostreecheck_run() {
 	ostree_rev="${OSTREE_DEPLOY##*/}"
 	ostree_rev="${ostree_rev%%.*}"
 	if [ -z "${ostree_rev}" ]; then
-		msg "No OSTree rev found"
+		msg "No OSTree rev found!"
 		return 1
 		#fatal
 	fi
 
-	msg "Checking contents of OSTree rev ${ostree_rev}"
+	msg "Checking contents of OSTree deployment at ${OSTREE_DEPLOY}"
 	# For now just look for modified or deleted usr files
 	# (We would expect to see a bunch of added etc and var files.)
 	# grep returns 0 if any matches are found
 	/usr/bin/ostree diff --repo=$ROOTFS_DIR/ostree/repo ${ostree_rev} ${OSTREE_DEPLOY} | grep "[MD] *usr/"
 	if [ $? -eq 0 ]; then
-		msg "OSTree deployment modified"
+		msg "OSTree deployment modified!"
 		#fatal
 	else
 		msg "OSTree deployment intact"
 	fi
+
+	# Put back ostree-booted, if it existed.
+	mv /run/ostree-booted.orig /run/ostree-booted 2> /dev/null
 }


### PR DESCRIPTION
OSTree script is failing due to the presence of /run/ostree-booted
in initramfs.

Issue raised at

https://github.com/ostreedev/ostree/issues/2485

Delete /run/ostree-booted from initramfs to make it work.

Also remove some stray debugging.