### PR TITLE
Add the parsec group to ETC_GROUP_MEMBERS

### DIFF
--- a/meta-lmp-support/recipes-core/images/console-image-lmp.bb
+++ b/meta-lmp-support/recipes-core/images/console-image-lmp.bb
@@ -117,6 +117,10 @@ EXTRA_USERS_PARAMS += "\
     useradd parsec;\
 "
 
+# Add the parsec group the ETC_GROUP_MEMBERS. This will allow the group to be added to user accounts,
+# via the useradd command
+ETC_GROUP_MEMBERS_append = " parsec"
+
 # modify the ownership of the folders and files that only the parsec user needs access to.
 
 ROOTFS_POSTPROCESS_COMMAND_append = " \


### PR DESCRIPTION
By adding the parsec group the the ETC_GROUP_MEMBERS variable, a new user can have the parsec group added.
e.g.
sudo useradd -G parsec -e $(date --date='1 week' --rfc-3339=date) -u 1250 bob
will allow user bob to access parsec services.
See also https://github.com/foundriesio/meta-lmp/pull/408