### PR TITLE
Remove kube verbose logs

### DIFF
--- a/recipes-containers/kubelet/files/launch-kubelet.sh
+++ b/recipes-containers/kubelet/files/launch-kubelet.sh
@@ -91,7 +91,6 @@ write_resolv_conf ${POD_CIDR_GW}
 setup_local_kaas_network ${NODE_IP}
 
 exec EDGE_BIN/kubelet \
---v=2 \
 --node-ip=${NODE_IP} \
 --root-dir=/var/lib/kubelet \
 --offline-cache-path=EDGE_KUBELET_STATE/store \


### PR DESCRIPTION
Verbose level 1 was still not enough, remove verbose completely.
There is still quite a lot of logs, example attached.
[journalctl.log](https://github.com/PelionIoT/meta-pelion-edge/files/7606495/journalctl.log)

