### PR TITLE
Change location of kube-router config to fix OSTree fail

### DIFF
--- a/recipes-containers/kube-router/files/launch-kube-router.sh
+++ b/recipes-containers/kube-router/files/launch-kube-router.sh
@@ -24,8 +24,13 @@ if [[ $? -ne 0 ]] || [[ $DEVICE_ID == null ]]; then
 fi
 
 POD_CIDR=EDGE_PODCIDR
+CONFIG=EDGE_RUN/kuberouter.conflist
 
-exec env NODE_NAME=${DEVICE_ID} KUBE_ROUTER_CNI_CONF_FILE=EDGE_CNI_CONF/10-kuberouter.conflist EDGE_BIN/kube-router \
+if [[ ! -f ${CONFIG} ]]; then
+	cp EDGE_CNI_CONF/10-kuberouter.conflist ${CONFIG}
+fi
+
+exec env NODE_NAME=${DEVICE_ID} KUBE_ROUTER_CNI_CONF_FILE=${CONFIG} EDGE_BIN/kube-router \
 --v=1 \
 --kubeconfig=EDGE_KUBELET_STATE/kubeconfig \
 --run-firewall=true \


### PR DESCRIPTION
OSTree check fails due to modified `/wigwag/system/etc/cni/net.d/10-kuberouter.conflist`. As kube-router needs to modify this file during runtime, make a copy in the `/run` directory and point kube-router to the copy.

The config file only holds state during runtime and can be reset when the device is rebooted.