### PR TITLE
kubelet.git -> refer to PelionIoT

### DIFF
--- a/recipes-containers/kubelet/kubelet_git.bb
+++ b/recipes-containers/kubelet/kubelet_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=3b83ef96387f14655fc854dd
 export GO111MODULE="auto"
 
 inherit go pkgconfig gitpkgv systemd edge
-SRC_URI = "git://git@github.com/armPelionEdge/edge-kubelet.git;protocol=https;nobranch=1;depth=1 \
+SRC_URI = "git://git@github.com/PelionIoT/edge-kubelet.git;protocol=https;nobranch=1;depth=1 \
 file://kubeconfig \
 file://kubelet.service \
 file://kubelet-watcher.service \


### PR DESCRIPTION
It is still referring to legacy domain.