### PR TITLE
Hotfix for opencontainers/runc branch rename.

### DIFF
--- a/meta-lmp-support/recipes-containers/runc/runc-opencontainers_git.bbappend
+++ b/meta-lmp-support/recipes-containers/runc/runc-opencontainers_git.bbappend
@@ -1,0 +1,5 @@
+SRC_URI = " \
+    git://github.com/opencontainers/runc;branch=main \
+    file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
+    "
+


### PR DESCRIPTION
The https://github.com/opencontainers/runc master branch has been
renamed to main.
https://github.com/opencontainers/runc/issues/3250

This bbappend changes the SRC_URI to use main, and overrides the default
in https://github.com/foundriesio/meta-lmp/blob/23c85c11395dddf1ed975bc30aa3ad76927024d8/meta-lmp-base/recipes-containers/runc/runc-opencontainers_git.bb