### PR TITLE
Update pe-utils to v 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     - updated libCurl to version 7.76.0.
     - Factory Configurator Client Example also updated to version 4.13.0.
 - Updated [LmP to version 85](https://foundries.io/products/releases/83/).
+- Updated `info` to version 2.0.12 (via pe-utils -repo).
+- New recipe for `testnet.sh` for verifying any firewall issues with connectivity (via pe-utils repo).
 
 # Edge 2.5.1 - 18th Jan 2021
 

--- a/recipes-misc/info-tool/info-tool_2.0.0.bb
+++ b/recipes-misc/info-tool/info-tool_2.0.0.bb
@@ -7,7 +7,7 @@ SRC_URI="\
 git://git@github.com/PelionIoT/pe-utils.git;protocol=https;name=pe-utils;destsuffix=git/pe-utils \
 "
 
-SRCREV_pe-utils = "2.0.11"
+SRCREV_pe-utils = "2.0.12"
 
 inherit pkgconfig gitpkgv edge
 
@@ -16,7 +16,8 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r0"
 
 DEPENDS = ""
-RDEPENDS_${PN} += "bash bc curl gawk findutils jq sed"
+# uname for example comes via coreutils
+RDEPENDS_${PN} += "coreutils bash bc curl gawk findutils jq sed"
 
 RM_WORK_EXCLUDE += "${PN}"
 

--- a/recipes-misc/testnet/testnet_2.0.0.bb
+++ b/recipes-misc/testnet/testnet_2.0.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/pe-utils/LICENSE;md5=1dece7821bf3fd70f
 SRC_URI="\
 git://git@github.com/PelionIoT/pe-utils.git;protocol=https;name=pe-utils;destsuffix=git/pe-utils \
 "
-SRCREV_pe-utils = "2.0.11"
+SRCREV_pe-utils = "2.0.12"
 
 inherit pkgconfig gitpkgv edge
 


### PR DESCRIPTION
`info` tool gets updated for real, `testnet.sh` just cosmetically.
